### PR TITLE
✨ implement recipe steps retrieval

### DIFF
--- a/backend/src/main/java/net/pengcook/recipe/controller/RecipeController.java
+++ b/backend/src/main/java/net/pengcook/recipe/controller/RecipeController.java
@@ -4,9 +4,10 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import net.pengcook.recipe.dto.MainRecipeRequest;
 import net.pengcook.recipe.dto.MainRecipeResponse;
+import net.pengcook.recipe.dto.RecipeStepResponse;
 import net.pengcook.recipe.service.RecipeService;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,5 +21,10 @@ public class RecipeController {
     @GetMapping
     public List<MainRecipeResponse> readRecipes(@RequestBody MainRecipeRequest request) {
         return recipeService.readRecipes(request);
+    }
+
+    @GetMapping("/{id}/steps")
+    public List<RecipeStepResponse> readRecipeSteps(@PathVariable long id) {
+        return recipeService.readRecipeSteps(id);
     }
 }

--- a/backend/src/main/java/net/pengcook/recipe/controller/RecipeController.java
+++ b/backend/src/main/java/net/pengcook/recipe/controller/RecipeController.java
@@ -2,13 +2,13 @@ package net.pengcook.recipe.controller;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import net.pengcook.recipe.dto.MainRecipeRequest;
 import net.pengcook.recipe.dto.MainRecipeResponse;
 import net.pengcook.recipe.dto.RecipeStepResponse;
 import net.pengcook.recipe.service.RecipeService;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -19,8 +19,8 @@ public class RecipeController {
     private final RecipeService recipeService;
 
     @GetMapping
-    public List<MainRecipeResponse> readRecipes(@RequestBody MainRecipeRequest request) {
-        return recipeService.readRecipes(request);
+    public List<MainRecipeResponse> readRecipes(@RequestParam int pageNumber, @RequestParam int pageSize) {
+        return recipeService.readRecipes(pageNumber, pageSize);
     }
 
     @GetMapping("/{id}/steps")

--- a/backend/src/main/java/net/pengcook/recipe/domain/Recipe.java
+++ b/backend/src/main/java/net/pengcook/recipe/domain/Recipe.java
@@ -8,13 +8,14 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import java.time.LocalTime;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import net.pengcook.user.domain.User;
 
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
 public class Recipe {

--- a/backend/src/main/java/net/pengcook/recipe/domain/RecipeStep.java
+++ b/backend/src/main/java/net/pengcook/recipe/domain/RecipeStep.java
@@ -6,9 +6,14 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public class RecipeStep {
 

--- a/backend/src/main/java/net/pengcook/recipe/domain/RecipeStep.java
+++ b/backend/src/main/java/net/pengcook/recipe/domain/RecipeStep.java
@@ -1,0 +1,32 @@
+package net.pengcook.recipe.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class RecipeStep {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @ManyToOne
+    @JoinColumn(name = "recipe_id")
+    private Recipe recipe;
+
+    private String image;
+
+    private String description;
+
+    private int sequence;
+
+    public long recipeId() {
+        return recipe.getId();
+    }
+}

--- a/backend/src/main/java/net/pengcook/recipe/dto/MainRecipeRequest.java
+++ b/backend/src/main/java/net/pengcook/recipe/dto/MainRecipeRequest.java
@@ -1,4 +1,0 @@
-package net.pengcook.recipe.dto;
-
-public record MainRecipeRequest(int pageNumber, int pageSize) {
-}

--- a/backend/src/main/java/net/pengcook/recipe/dto/RecipeStepResponse.java
+++ b/backend/src/main/java/net/pengcook/recipe/dto/RecipeStepResponse.java
@@ -1,0 +1,16 @@
+package net.pengcook.recipe.dto;
+
+import net.pengcook.recipe.domain.RecipeStep;
+
+public record RecipeStepResponse(long id, long recipeId, String image, String description, int sequence) {
+
+    public RecipeStepResponse(RecipeStep recipeStep) {
+        this(
+                recipeStep.getId(),
+                recipeStep.recipeId(),
+                recipeStep.getImage(),
+                recipeStep.getDescription(),
+                recipeStep.getSequence()
+        );
+    }
+}

--- a/backend/src/main/java/net/pengcook/recipe/repository/RecipeStepRepository.java
+++ b/backend/src/main/java/net/pengcook/recipe/repository/RecipeStepRepository.java
@@ -1,0 +1,10 @@
+package net.pengcook.recipe.repository;
+
+import java.util.List;
+import net.pengcook.recipe.domain.RecipeStep;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RecipeStepRepository extends JpaRepository<RecipeStep, Long> {
+
+    List<RecipeStep> findAllByRecipeId(long id);
+}

--- a/backend/src/main/java/net/pengcook/recipe/repository/RecipeStepRepository.java
+++ b/backend/src/main/java/net/pengcook/recipe/repository/RecipeStepRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RecipeStepRepository extends JpaRepository<RecipeStep, Long> {
 
-    List<RecipeStep> findAllByRecipeId(long id);
+    List<RecipeStep> findAllByRecipeIdOrderBySequence(long id);
 }

--- a/backend/src/main/java/net/pengcook/recipe/service/RecipeService.java
+++ b/backend/src/main/java/net/pengcook/recipe/service/RecipeService.java
@@ -34,7 +34,7 @@ public class RecipeService {
     }
 
     public List<RecipeStepResponse> readRecipeSteps(long id) {
-        List<RecipeStep> recipeSteps = recipeStepRepository.findAllByRecipeId(id);
+        List<RecipeStep> recipeSteps = recipeStepRepository.findAllByRecipeIdOrderBySequence(id);
         return convertToRecipeStepResponses(recipeSteps);
     }
 

--- a/backend/src/main/java/net/pengcook/recipe/service/RecipeService.java
+++ b/backend/src/main/java/net/pengcook/recipe/service/RecipeService.java
@@ -9,7 +9,6 @@ import net.pengcook.recipe.domain.RecipeStep;
 import net.pengcook.recipe.dto.AuthorResponse;
 import net.pengcook.recipe.dto.CategoryResponse;
 import net.pengcook.recipe.dto.IngredientResponse;
-import net.pengcook.recipe.dto.MainRecipeRequest;
 import net.pengcook.recipe.dto.MainRecipeResponse;
 import net.pengcook.recipe.dto.RecipeDataResponse;
 import net.pengcook.recipe.dto.RecipeStepResponse;
@@ -26,8 +25,8 @@ public class RecipeService {
     private final RecipeRepository recipeRepository;
     private final RecipeStepRepository recipeStepRepository;
 
-    public List<MainRecipeResponse> readRecipes(MainRecipeRequest request) {
-        Pageable pageable = PageRequest.of(request.pageNumber(), request.pageSize());
+    public List<MainRecipeResponse> readRecipes(int pageNumber, int pageSize) {
+        Pageable pageable = PageRequest.of(pageNumber, pageSize);
         List<Long> recipeIds = recipeRepository.findRecipeIds(pageable);
 
         List<RecipeDataResponse> recipeDataResponses = recipeRepository.findRecipeData(recipeIds);

--- a/backend/src/main/java/net/pengcook/recipe/service/RecipeService.java
+++ b/backend/src/main/java/net/pengcook/recipe/service/RecipeService.java
@@ -5,13 +5,16 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import net.pengcook.recipe.domain.RecipeStep;
 import net.pengcook.recipe.dto.AuthorResponse;
 import net.pengcook.recipe.dto.CategoryResponse;
 import net.pengcook.recipe.dto.IngredientResponse;
 import net.pengcook.recipe.dto.MainRecipeRequest;
 import net.pengcook.recipe.dto.MainRecipeResponse;
 import net.pengcook.recipe.dto.RecipeDataResponse;
+import net.pengcook.recipe.dto.RecipeStepResponse;
 import net.pengcook.recipe.repository.RecipeRepository;
+import net.pengcook.recipe.repository.RecipeStepRepository;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -21,6 +24,7 @@ import org.springframework.stereotype.Service;
 public class RecipeService {
 
     private final RecipeRepository recipeRepository;
+    private final RecipeStepRepository recipeStepRepository;
 
     public List<MainRecipeResponse> readRecipes(MainRecipeRequest request) {
         Pageable pageable = PageRequest.of(request.pageNumber(), request.pageSize());
@@ -28,6 +32,17 @@ public class RecipeService {
 
         List<RecipeDataResponse> recipeDataResponses = recipeRepository.findRecipeData(recipeIds);
         return convertToMainRecipeResponses(recipeDataResponses);
+    }
+
+    public List<RecipeStepResponse> readRecipeSteps(long id) {
+        List<RecipeStep> recipeSteps = recipeStepRepository.findAllByRecipeId(id);
+        return convertToRecipeStepResponses(recipeSteps);
+    }
+
+    private List<RecipeStepResponse> convertToRecipeStepResponses(List<RecipeStep> recipeSteps) {
+        return recipeSteps.stream()
+                .map(RecipeStepResponse::new)
+                .toList();
     }
 
     public List<MainRecipeResponse> convertToMainRecipeResponses(List<RecipeDataResponse> recipeDataResponses) {

--- a/backend/src/test/java/net/pengcook/recipe/controller/RecipeControllerTest.java
+++ b/backend/src/test/java/net/pengcook/recipe/controller/RecipeControllerTest.java
@@ -34,4 +34,15 @@ class RecipeControllerTest {
                 .then().log().all()
                 .body("size()", is(3));
     }
+
+    @Test
+    @DisplayName("레시피 상세 스텝을 조회한다.")
+    void readRecipeSteps() {
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .when()
+                .get("/api/recipes/1/steps")
+                .then().log().all()
+                .body("size()", is(3));
+    }
 }

--- a/backend/src/test/java/net/pengcook/recipe/controller/RecipeControllerTest.java
+++ b/backend/src/test/java/net/pengcook/recipe/controller/RecipeControllerTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.is;
 
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
-import net.pengcook.recipe.dto.MainRecipeRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -28,13 +27,10 @@ class RecipeControllerTest {
     @Test
     @DisplayName("레시피 개요 목록을 조회한다.")
     void readRecipes() {
-        MainRecipeRequest request = new MainRecipeRequest(0, 3);
-
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
-                .body(request)
                 .when()
-                .get("/api/recipes")
+                .get("/api/recipes?pageNumber=0&pageSize=3")
                 .then().log().all()
                 .body("size()", is(3));
     }

--- a/backend/src/test/java/net/pengcook/recipe/service/RecipeServiceTest.java
+++ b/backend/src/test/java/net/pengcook/recipe/service/RecipeServiceTest.java
@@ -3,7 +3,6 @@ package net.pengcook.recipe.service;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
-import net.pengcook.recipe.dto.MainRecipeRequest;
 import net.pengcook.recipe.dto.MainRecipeResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -25,9 +24,7 @@ class RecipeServiceTest {
     @CsvSource(value = {"0,2,4", "1,2,2", "1,3,1"})
     @DisplayName("요청받은 페이지의 레시피 개요 목록을 조회한다.")
     void readRecipes(int pageNumber, int pageSize, int expectedFirstRecipeId) {
-        MainRecipeRequest request = new MainRecipeRequest(pageNumber, pageSize);
-
-        List<MainRecipeResponse> mainRecipeResponses = recipeService.readRecipes(request);
+        List<MainRecipeResponse> mainRecipeResponses = recipeService.readRecipes(pageNumber, pageSize);
 
         assertThat(mainRecipeResponses.getFirst().recipeId()).isEqualTo(expectedFirstRecipeId);
     }

--- a/backend/src/test/java/net/pengcook/recipe/service/RecipeServiceTest.java
+++ b/backend/src/test/java/net/pengcook/recipe/service/RecipeServiceTest.java
@@ -2,9 +2,12 @@ package net.pengcook.recipe.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Arrays;
 import java.util.List;
 import net.pengcook.recipe.dto.MainRecipeResponse;
+import net.pengcook.recipe.dto.RecipeStepResponse;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,5 +30,20 @@ class RecipeServiceTest {
         List<MainRecipeResponse> mainRecipeResponses = recipeService.readRecipes(pageNumber, pageSize);
 
         assertThat(mainRecipeResponses.getFirst().recipeId()).isEqualTo(expectedFirstRecipeId);
+    }
+
+    @Test
+    @DisplayName("특정 레시피의 스텝을 sequence 순서로 조회한다.")
+    void readRecipeSteps() {
+        long recipeId = 1L;
+        List<RecipeStepResponse> expectedRecipeStepResponses = Arrays.asList(
+                new RecipeStepResponse(1L, 1, "레시피1 설명1 이미지", "레시피1 설명1", 1),
+                new RecipeStepResponse(3L, 1, "레시피1 설명2 이미지", "레시피1 설명2", 2),
+                new RecipeStepResponse(2L, 1, "레시피1 설명3 이미지", "레시피1 설명3", 3)
+        );
+
+        List<RecipeStepResponse> recipeStepResponses = recipeService.readRecipeSteps(recipeId);
+
+        assertThat(recipeStepResponses).isEqualTo(expectedRecipeStepResponses);
     }
 }

--- a/backend/src/test/resources/data/recipe.sql
+++ b/backend/src/test/resources/data/recipe.sql
@@ -18,6 +18,9 @@ ALTER TABLE category_recipe ALTER COLUMN id RESTART;
 TRUNCATE TABLE ingredient_recipe;
 ALTER TABLE ingredient_recipe ALTER COLUMN id RESTART;
 
+TRUNCATE TABLE recipe_step;
+ALTER TABLE recipe_step ALTER COLUMN id RESTART;
+
 SET REFERENTIAL_INTEGRITY TRUE;
 
 INSERT INTO users (email, username, nickname, image, birth, region)
@@ -76,3 +79,8 @@ VALUES (1, 1, 'REQUIRED'),
        (3, 3, 'REQUIRED'),
        (7, 3, 'REQUIRED'),
        (2, 4, 'REQUIRED');
+
+INSERT INTO recipe_step (recipe_id, image, description, sequence)
+VALUES (1, '레시피1 설명1 이미지', '레시피1 설명1', 1),
+       (1, '레시피1 설명3 이미지', '레시피1 설명3', 3),
+       (1, '레시피1 설명2 이미지', '레시피1 설명2', 2);


### PR DESCRIPTION
### 구현 API
```/api/recipes/{id}/steps```

### 수정 API
```/api/recipes```

### 참고사항
- 레시피 Id를 통한 레시피 검색이 추가될 것을 고려해서, 스텝 조회 엔드포인트를 특정 레시피의 steps를 가져온다는 흐름으로 설정했습니다.
- 메인페이지에서 레시피 목록 조회시 페이지 정보를 body로 받던 것을 RequestParam으로 받아오도록 수정했습니다.
(이 부분은 별도 이슈로 관리되어야 했던 것 같은데 리팩토링 하다보니 같이 작업하게 됐습니다. 다음번에는 분리하겠습니다!)
