### PR TITLE
✨ add rest docs and swagger ui for category test

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### API Spec ###
+src/main/resources/static/openapi3.yaml

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -1,19 +1,9 @@
-import org.hidetake.gradle.swagger.generator.GenerateSwaggerUI
-import org.springframework.boot.gradle.tasks.bundling.BootJar
-
-buildscript {
-	ext {
-		restdocsApiSpecVersion = '0.16.2'
-	}
-}
-
 plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.2.7'
 	id 'io.spring.dependency-management' version '1.1.5'
 	id 'jacoco'
-	id 'com.epages.restdocs-api-spec' version "${restdocsApiSpecVersion}"
-	id 'org.hidetake.swagger.generator' version '2.18.2'
+	id 'com.epages.restdocs-api-spec' version '0.18.2'
 }
 
 group = 'net.pengcook'
@@ -35,20 +25,6 @@ repositories {
 	mavenCentral()
 }
 
-swaggerSources {
-	sample {
-		setInputFile(file("${project.buildDir}/api-spec/openapi3.yaml"))
-	}
-}
-
-openapi3 {
-	setServer("http://localhost:8080")
-	title = "restdocs-swagger API Documentation"
-	description = "Spring REST Docs with SwaggerUI."
-	version = "0.0.1"
-	format = "yaml"
-}
-
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -63,14 +39,23 @@ dependencies {
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'io.rest-assured:rest-assured'
-	testImplementation "com.epages:restdocs-api-spec-restassured:${restdocsApiSpecVersion}"
+	testImplementation 'org.springframework.restdocs:spring-restdocs-restassured'
+	testImplementation 'com.epages:restdocs-api-spec-restassured:0.18.2'
+	testImplementation 'com.epages:restdocs-api-spec-mockmvc:0.18.2'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	swaggerUI 'org.webjars:swagger-ui:4.11.1'
 }
 
 test {
 	useJUnitPlatform()
 	systemProperty 'spring.profiles.active', 'test'
+}
+
+openapi3 {
+	server = 'https://localhost:8080'
+	title = 'My API'
+	description = 'My API description'
+	version = '0.1.0'
+	format = 'yaml'
 }
 
 jar {
@@ -84,19 +69,4 @@ jacocoTestReport {
 		csv.required = false
 		html.required = false
 	}
-}
-
-tasks.withType(GenerateSwaggerUI) {
-	dependsOn 'openapi3'
-}
-
-tasks.register('copySwaggerUI', Copy) {
-	dependsOn 'generateSwaggerUISample'
-	def generateSwaggerUISampleTask = tasks.named('generateSwaggerUISample', GenerateSwaggerUI).get()
-	from("${generateSwaggerUISampleTask.outputDir}")
-	into("${project.buildDir}/resources/main/static/docs")
-}
-
-tasks.withType(BootJar) {
-	dependsOn 'copySwaggerUI'
 }

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -1,8 +1,19 @@
+import org.hidetake.gradle.swagger.generator.GenerateSwaggerUI
+import org.springframework.boot.gradle.tasks.bundling.BootJar
+
+buildscript {
+	ext {
+		restdocsApiSpecVersion = '0.16.2'
+	}
+}
+
 plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.2.7'
 	id 'io.spring.dependency-management' version '1.1.5'
 	id 'jacoco'
+	id 'com.epages.restdocs-api-spec' version "${restdocsApiSpecVersion}"
+	id 'org.hidetake.swagger.generator' version '2.18.2'
 }
 
 group = 'net.pengcook'
@@ -24,6 +35,20 @@ repositories {
 	mavenCentral()
 }
 
+swaggerSources {
+	sample {
+		setInputFile(file("${project.buildDir}/api-spec/openapi3.yaml"))
+	}
+}
+
+openapi3 {
+	setServer("http://localhost:8080")
+	title = "restdocs-swagger API Documentation"
+	description = "Spring REST Docs with SwaggerUI."
+	version = "0.0.1"
+	format = "yaml"
+}
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -38,7 +63,9 @@ dependencies {
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'io.rest-assured:rest-assured'
+	testImplementation "com.epages:restdocs-api-spec-restassured:${restdocsApiSpecVersion}"
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	swaggerUI 'org.webjars:swagger-ui:4.11.1'
 }
 
 test {
@@ -57,4 +84,19 @@ jacocoTestReport {
 		csv.required = false
 		html.required = false
 	}
+}
+
+tasks.withType(GenerateSwaggerUI) {
+	dependsOn 'openapi3'
+}
+
+tasks.register('copySwaggerUI', Copy) {
+	dependsOn 'generateSwaggerUISample'
+	def generateSwaggerUISampleTask = tasks.named('generateSwaggerUISample', GenerateSwaggerUI).get()
+	from("${generateSwaggerUISampleTask.outputDir}")
+	into("${project.buildDir}/resources/main/static/docs")
+}
+
+tasks.withType(BootJar) {
+	dependsOn 'copySwaggerUI'
 }

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 	implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5'
 	implementation 'com.google.firebase:firebase-admin:9.3.0'
 	implementation 'com.auth0:java-jwt:4.4.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 
 	runtimeOnly 'mysql:mysql-connector-java:8.0.33'
 	runtimeOnly 'com.h2database:h2'
@@ -38,11 +39,24 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'io.rest-assured:rest-assured'
 	testImplementation 'org.springframework.restdocs:spring-restdocs-restassured'
 	testImplementation 'com.epages:restdocs-api-spec-restassured:0.18.2'
 	testImplementation 'com.epages:restdocs-api-spec-mockmvc:0.18.2'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+ext {
+	profile = project.hasProperty('profile') ? project.profile : 'local'
+	serverUrl = 'http://localhost:8080'
+
+	switch (profile) {
+		case 'dev':
+			serverUrl = 'https://dev.pengcook.net'
+			break
+		case 'prod':
+			serverUrl = 'https://www.pengcook.net'
+			break
+	}
 }
 
 test {
@@ -51,11 +65,22 @@ test {
 }
 
 openapi3 {
-	server = 'https://localhost:8080'
-	title = 'My API'
-	description = 'My API description'
+	server = serverUrl
+	title = 'Pengcook API'
+	description = 'Pengcook API description'
 	version = '0.1.0'
 	format = 'yaml'
+}
+
+tasks.register("copyOasToSwagger", Copy) {
+	dependsOn("openapi3")
+
+	from layout.buildDirectory.file("api-spec/openapi3.yaml").get().asFile
+	into "src/main/resources/static"
+}
+
+bootJar {
+	dependsOn copyOasToSwagger
 }
 
 jar {

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -6,3 +6,8 @@ spring:
 jasypt:
   encryptor:
     password: ${JASYPT_PASSWORD}
+
+springdoc:
+  enable-default-api-docs: false
+  api-docs:
+    path: /openapi3.yaml

--- a/backend/src/test/java/net/pengcook/RestDocsSetting.java
+++ b/backend/src/test/java/net/pengcook/RestDocsSetting.java
@@ -1,8 +1,5 @@
 package net.pengcook;
 
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
-import static org.springframework.restdocs.restassured.RestAssuredRestDocumentation.documentationConfiguration;
-
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.specification.RequestSpecification;
@@ -13,14 +10,17 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyHeaders;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.restassured.RestAssuredRestDocumentation.documentationConfiguration;
+
 @ExtendWith(RestDocumentationExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public abstract class RestDocsSetting {
 
     protected static final String DEFAULT_RESTDOCS_PATH = "{class_name}/{method_name}/";
 
     protected RequestSpecification spec;
-
     @LocalServerPort
     int port;
 
@@ -31,12 +31,22 @@ public abstract class RestDocsSetting {
 
     @BeforeEach
     void setUpRestDocs(RestDocumentationContextProvider restDocumentation) {
-        this.spec = new RequestSpecBuilder()
-                .setPort(port)
+        spec = new RequestSpecBuilder()
                 .addFilter(documentationConfiguration(restDocumentation)
                         .operationPreprocessors()
-                        .withRequestDefaults(prettyPrint())
-                        .withResponseDefaults(prettyPrint()))
+                        .withRequestDefaults(prettyPrint(), modifyHeaders()
+                                .remove("Host")
+                                .remove("Content-Length")
+                        )
+                        .withResponseDefaults(prettyPrint(), modifyHeaders()
+                                .remove("Transfer-Encoding")
+                                .remove("Keep-Alive")
+                                .remove("Date")
+                                .remove("Connection")
+                                .remove("Content-Length")
+                        )
+                )
+                .setPort(port)
                 .build();
     }
 }

--- a/backend/src/test/java/net/pengcook/RestDocsSetting.java
+++ b/backend/src/test/java/net/pengcook/RestDocsSetting.java
@@ -1,0 +1,42 @@
+package net.pengcook;
+
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.restassured.RestAssuredRestDocumentation.documentationConfiguration;
+
+import io.restassured.RestAssured;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.specification.RequestSpecification;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ExtendWith(RestDocumentationExtension.class)
+public abstract class RestDocsSetting {
+
+    protected static final String DEFAULT_RESTDOCS_PATH = "{class_name}/{method_name}/";
+
+    protected RequestSpecification spec;
+
+    @LocalServerPort
+    int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @BeforeEach
+    void setUpRestDocs(RestDocumentationContextProvider restDocumentation) {
+        this.spec = new RequestSpecBuilder()
+                .setPort(port)
+                .addFilter(documentationConfiguration(restDocumentation)
+                        .operationPreprocessors()
+                        .withRequestDefaults(prettyPrint())
+                        .withResponseDefaults(prettyPrint()))
+                .build();
+    }
+}

--- a/backend/src/test/java/net/pengcook/category/controller/CategoryControllerTest.java
+++ b/backend/src/test/java/net/pengcook/category/controller/CategoryControllerTest.java
@@ -1,13 +1,15 @@
 package net.pengcook.category.controller;
 
-import static org.hamcrest.Matchers.is;
-import static org.springframework.restdocs.restassured.RestAssuredRestDocumentation.document;
-
 import io.restassured.RestAssured;
 import net.pengcook.RestDocsSetting;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.jdbc.Sql;
+
+import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 
 @Sql(value = "/data/category.sql")
 class CategoryControllerTest extends RestDocsSetting {
@@ -16,12 +18,16 @@ class CategoryControllerTest extends RestDocsSetting {
     @DisplayName("레시피 개요 목록을 조회한다.")
     void readRecipes() {
         RestAssured.given(spec).log().all()
-                .filter(document("카테고리 목록 조회 API"))
+                .filter(document(DEFAULT_RESTDOCS_PATH,
+                        requestFields(
+                                fieldWithPath("category").description("카테고리"),
+                                fieldWithPath("pageNumber").description("페이지 번호"),
+                                fieldWithPath("pageSize").description("페이지 크기")
+                        )))
                 .queryParam("category", "한식")
                 .queryParam("pageNumber", 0)
                 .queryParam("pageSize", 3)
-                .when()
-                .get("/api/categories")
+                .when().get("/api/categories")
                 .then().log().all()
                 .body("size()", is(3));
     }

--- a/backend/src/test/java/net/pengcook/category/controller/CategoryControllerTest.java
+++ b/backend/src/test/java/net/pengcook/category/controller/CategoryControllerTest.java
@@ -8,8 +8,8 @@ import org.springframework.test.context.jdbc.Sql;
 
 import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
 import static org.hamcrest.Matchers.is;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 
 @Sql(value = "/data/category.sql")
 class CategoryControllerTest extends RestDocsSetting {
@@ -19,10 +19,10 @@ class CategoryControllerTest extends RestDocsSetting {
     void readRecipes() {
         RestAssured.given(spec).log().all()
                 .filter(document(DEFAULT_RESTDOCS_PATH,
-                        requestFields(
-                                fieldWithPath("category").description("카테고리"),
-                                fieldWithPath("pageNumber").description("페이지 번호"),
-                                fieldWithPath("pageSize").description("페이지 크기")
+                        queryParameters(
+                                parameterWithName("category").description("카테고리"),
+                                parameterWithName("pageNumber").description("페이지 번호"),
+                                parameterWithName("pageSize").description("페이지 크기")
                         )))
                 .queryParam("category", "한식")
                 .queryParam("pageNumber", 0)

--- a/backend/src/test/java/net/pengcook/category/controller/CategoryControllerTest.java
+++ b/backend/src/test/java/net/pengcook/category/controller/CategoryControllerTest.java
@@ -8,6 +8,8 @@ import org.springframework.test.context.jdbc.Sql;
 
 import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
 import static org.hamcrest.Matchers.is;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 
@@ -23,7 +25,28 @@ class CategoryControllerTest extends RestDocsSetting {
                                 parameterWithName("category").description("카테고리"),
                                 parameterWithName("pageNumber").description("페이지 번호"),
                                 parameterWithName("pageSize").description("페이지 크기")
-                        )))
+                        ),
+                        responseFields(
+                                fieldWithPath("[]").description("레시피 목록"),
+                                fieldWithPath("[].recipeId").description("레시피 아이디"),
+                                fieldWithPath("[].title").description("레시피 제목"),
+                                fieldWithPath("[].author").description("작성자 정보"),
+                                fieldWithPath("[].author.authorId").description("작성자 아이디"),
+                                fieldWithPath("[].author.authorName").description("작성자 이름"),
+                                fieldWithPath("[].author.authorImage").description("작성자 이미지"),
+                                fieldWithPath("[].cookingTime").description("조리 시간"),
+                                fieldWithPath("[].thumbnail").description("썸네일 이미지"),
+                                fieldWithPath("[].difficulty").description("난이도"),
+                                fieldWithPath("[].likeCount").description("좋아요 수"),
+                                fieldWithPath("[].description").description("레시피 설명"),
+                                fieldWithPath("[].category").description("카테고리 목록"),
+                                fieldWithPath("[].category[].categoryId").description("카테고리 아이디"),
+                                fieldWithPath("[].category[].categoryName").description("카테고리 이름"),
+                                fieldWithPath("[].ingredient").description("재료 목록"),
+                                fieldWithPath("[].ingredient[].ingredientId").description("재료 아이디"),
+                                fieldWithPath("[].ingredient[].ingredientName").description("재료 이름"),
+                                fieldWithPath("[].ingredient[].requirement").description("재료 필수 여부")
+                                )))
                 .queryParam("category", "한식")
                 .queryParam("pageNumber", 0)
                 .queryParam("pageSize", 3)

--- a/backend/src/test/java/net/pengcook/category/controller/CategoryControllerTest.java
+++ b/backend/src/test/java/net/pengcook/category/controller/CategoryControllerTest.java
@@ -1,32 +1,22 @@
 package net.pengcook.category.controller;
 
 import static org.hamcrest.Matchers.is;
+import static org.springframework.restdocs.restassured.RestAssuredRestDocumentation.document;
 
 import io.restassured.RestAssured;
-import org.junit.jupiter.api.BeforeEach;
+import net.pengcook.RestDocsSetting;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.context.jdbc.Sql;
 
-@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @Sql(value = "/data/category.sql")
-class CategoryControllerTest {
-
-    @LocalServerPort
-    private int port;
-
-    @BeforeEach
-    void setUp() {
-        RestAssured.port = port;
-    }
+class CategoryControllerTest extends RestDocsSetting {
 
     @Test
     @DisplayName("레시피 개요 목록을 조회한다.")
     void readRecipes() {
-        RestAssured.given().log().all()
+        RestAssured.given(spec).log().all()
+                .filter(document("카테고리 목록 조회 API"))
                 .queryParam("category", "한식")
                 .queryParam("pageNumber", 0)
                 .queryParam("pageSize", 3)


### PR DESCRIPTION
build.gradle에 의존성과 task를 추가해 rest docs와 swagger ui를 도입했습니다.

사용 방법은 다음과 같습니다.

1. 컨트롤러 E2E 테스트를 `RestDocsSetting`을 상속받게 변경합니다.

2. 각 테스트에 rest docs에서 요구하는 요소를 추가합니다.
    - `given`에 파라미터로 `spec`을 넣습니다. `spec`은 `RestDocsSetting`에 이미 정의되어있으니 가져다 쓰시면 됩니다.
    - `given.log.all` 뒤에 `filter` 메서드를 추가합니다. 형태는 `CategoryControllerTest`를 보시면 이해가 빠를 겁니다.
    - 뭘 추가해야할지 모르시겠다면... 불러주세요. 함께 공부합시다.
4. 이후 Gradle bootJar을 실행하면 openapi3.yaml 이 resources/static 으로 들어옵니다.
5. [http://localhost:8080/swagger-ui/index.html](http://localhost:8080/swagger-ui/index.html)로 접속하면 기존의 swagger로 만든 api 문서와 동일한 결과를 보실 수 있습니다.

궁금한 부분이 있다면 질문 주세요.
special thanks to 새양 입니다.