### PR TITLE
✨  create login test annotation

### DIFF
--- a/backend/src/test/java/net/pengcook/authentication/annotation/WithLoginUser.java
+++ b/backend/src/test/java/net/pengcook/authentication/annotation/WithLoginUser.java
@@ -1,0 +1,23 @@
+package net.pengcook.authentication.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface WithLoginUser {
+
+    String email() default "tester@pengcook.net";
+
+    String username() default "tester";
+
+    String nickname() default "테스트 유저";
+
+    String image() default "tester.jpg";
+
+    String birth() default "2000-01-01";
+
+    String region() default "KOREA";
+}

--- a/backend/src/test/java/net/pengcook/authentication/annotation/WithLoginUserTest.java
+++ b/backend/src/test/java/net/pengcook/authentication/annotation/WithLoginUserTest.java
@@ -1,0 +1,14 @@
+package net.pengcook.authentication.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import net.pengcook.authentication.extension.LoginExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(LoginExtension.class)
+public @interface WithLoginUserTest {
+}

--- a/backend/src/test/java/net/pengcook/authentication/extension/LoginExtension.java
+++ b/backend/src/test/java/net/pengcook/authentication/extension/LoginExtension.java
@@ -1,0 +1,57 @@
+package net.pengcook.authentication.extension;
+
+import io.restassured.RestAssured;
+import java.time.LocalDate;
+import net.pengcook.authentication.annotation.WithLoginUser;
+import net.pengcook.authentication.dto.TokenPayload;
+import net.pengcook.authentication.util.JwtTokenManager;
+import net.pengcook.user.domain.User;
+import net.pengcook.user.repository.UserRepository;
+import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+public class LoginExtension implements BeforeEachCallback, AfterTestExecutionCallback {
+
+    @Override
+    public void beforeEach(ExtensionContext context) {
+
+        WithLoginUser annotation = context.getRequiredTestMethod().getAnnotation(WithLoginUser.class);
+        if (annotation != null) {
+            ApplicationContext applicationContext = SpringExtension.getApplicationContext(context);
+            JwtTokenManager jwtTokenManager = applicationContext.getBean(JwtTokenManager.class);
+            UserRepository userRepository = applicationContext.getBean(UserRepository.class);
+
+            User user = findOrSaveUser(annotation, userRepository);
+            String accessToken = jwtTokenManager.createToken(new TokenPayload(user.getId(), user.getEmail()));
+
+            RestAssured.port = ((ServletWebServerApplicationContext) applicationContext).getWebServer().getPort();
+            RestAssured.requestSpecification = RestAssured.given().header("Authorization", "Bearer " + accessToken);
+        }
+    }
+
+    @Override
+    public void afterTestExecution(ExtensionContext extensionContext) {
+        RestAssured.reset();
+    }
+
+    private User findOrSaveUser(WithLoginUser annotation, UserRepository userRepository) {
+        return userRepository.findByEmail(annotation.email())
+                .orElseGet(() -> saveUser(annotation, userRepository));
+    }
+
+    private User saveUser(WithLoginUser annotation, UserRepository userRepository) {
+        User user = new User(
+                annotation.email(),
+                annotation.username(),
+                annotation.nickname(),
+                annotation.image(),
+                LocalDate.parse(annotation.birth()),
+                annotation.region()
+        );
+        return userRepository.save(user);
+    }
+}


### PR DESCRIPTION
## 구현
E2E 테스트시 로그인 테스트를 쉽게 하기위해 어노테이션을 만들었습니다.

## 사용법

1. 사용할 ControllerTest 단에 `@WithLoginUserTest`을 붙여줍니다.
```java
@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
@WithLoginUserTest
@Sql("/data/users.sql")
class UserControllerTest {
...

```

2. 사용할 메서드에  `@WithLoginUser`를 붙여줍니다.
  - 인자 없이 전달하면 기본값으로 `tester@pengcook.net` 이메일을 가지는 테스트 유저가 생성되고 로그인됨
  - (email, username, nickname, image, birth, region)을 설정할 수 있음. `data.sql`에 이미 있는 email의 유저를 만들면 다시 생성되지 않고 기존 유저를 찾아옴.
  - 가짜 로그인이 아니라 실제로 userRepository에 저장됨. 테스트중 유저가 필요하면 userRepository.findByEmail을 통해 조회 가능

```java
    @Test
    @WithLoginUser(email = "loki@pengcook.net")
    @DisplayName("사용자의 정보를 조회한다.")
    void getUserProfile() {
        long id = 1L;
        UserResponse expected = new UserResponse(
                id,
                "loki@pengcook.net",
                "loki",
                "로키",
                "loki.jpg",
                LocalDate.of(1999, 8, 8),
                "KOREA"
        );

        UserResponse actual = RestAssured.given().log().all()
                .contentType(ContentType.JSON)
                .when().get("/api/user/me")
                .then().log().all()
                .statusCode(200)
                .extract()
                .as(UserResponse.class);

        assertThat(actual).isEqualTo(expected);
    }
```

3. RestAssured에 따로 헤더를 정의하지 않아도 다음과 같이 토큰이 들어가서 로그인이됨


![스크린샷 2024-07-29 오전 12 20 03](https://github.com/user-attachments/assets/ae95a89e-9b42-4c0d-b779-2999844d96e0)
