### PR TITLE
✨ add log monitoring dashboard

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 	implementation 'com.google.firebase:firebase-admin:9.3.0'
 	implementation 'com.auth0:java-jwt:4.4.0'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+	implementation 'com.github.loki4j:loki-logback-appender:1.5.1'
 
 	runtimeOnly 'mysql:mysql-connector-java:8.0.33'
 	runtimeOnly 'com.h2database:h2'

--- a/backend/src/main/resources/docker-compose-dev.yaml
+++ b/backend/src/main/resources/docker-compose-dev.yaml
@@ -21,6 +21,41 @@ services:
     environment:
       JASYPT_PASSWORD: ${JASYPT_PASSWORD}
     ports:
-      - 7848:8080
+      - 8080:8080
     links:
       - db
+      - loki
+
+  loki:
+    image: grafana/loki
+    command: -config.file=/etc/loki/local-config.yaml
+
+  grafana:
+    environment:
+      - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+    entrypoint:
+      - sh
+      - -euc
+      - |
+        mkdir -p /etc/grafana/provisioning/datasources
+        cat <<EOF > /etc/grafana/provisioning/datasources/ds.yaml
+        apiVersion: 1
+        datasources:
+        - name: Loki
+          type: loki
+          access: proxy
+          orgId: 1
+          url: http://loki:3100
+          basicAuth: false
+          isDefault: true
+          version: 1
+          editable: false
+        EOF
+        /run.sh
+    image: grafana/grafana
+    ports:
+      - 3000:3000
+    links:
+      - loki

--- a/backend/src/main/resources/docker-compose-local.yaml
+++ b/backend/src/main/resources/docker-compose-local.yaml
@@ -50,3 +50,5 @@ services:
     image: grafana/grafana
     ports:
       - 3000:3000
+    links:
+      - loki

--- a/backend/src/main/resources/docker-compose-local.yaml
+++ b/backend/src/main/resources/docker-compose-local.yaml
@@ -16,3 +16,37 @@ services:
     command:
       - --character-set-server=utf8
       - --collation-server=utf8_general_ci
+
+  loki:
+    image: grafana/loki
+    ports:
+      - 3100:3100
+    command: -config.file=/etc/loki/local-config.yaml
+
+  grafana:
+    environment:
+      - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+    entrypoint:
+      - sh
+      - -euc
+      - |
+        mkdir -p /etc/grafana/provisioning/datasources
+        cat <<EOF > /etc/grafana/provisioning/datasources/ds.yaml
+        apiVersion: 1
+        datasources:
+        - name: Loki
+          type: loki
+          access: proxy
+          orgId: 1
+          url: http://loki:3100
+          basicAuth: false
+          isDefault: true
+          version: 1
+          editable: false
+        EOF
+        /run.sh
+    image: grafana/grafana
+    ports:
+      - 3000:3000

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -1,8 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+    <springProfile name="local">
+        <property name="LOKI_URL" value="http://localhost:3100/loki/api/v1/push"/>
+    </springProfile>
+
+    <springProfile name="dev">
+        <property name="LOKI_URL" value="http://loki:3100/loki/api/v1/push"/>
+    </springProfile>
+
     <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
         <http>
-            <url>http://localhost:3100/loki/api/v1/push</url>
+            <url>${LOKI_URL}</url>
         </http>
         <format>
             <label>
@@ -24,6 +32,6 @@
     </appender>
 
     <root level="INFO">
-        <appender-ref ref="LOKI" />
+        <appender-ref ref="LOKI"/>
     </root>
 </configuration>

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -4,6 +4,10 @@
         <property name="LOKI_URL" value="http://localhost:3100/loki/api/v1/push"/>
     </springProfile>
 
+    <springProfile name="test">
+        <property name="LOKI_URL" value="http://localhost:3100/loki/api/v1/push"/>
+    </springProfile>
+
     <springProfile name="dev">
         <property name="LOKI_URL" value="http://loki:3100/loki/api/v1/push"/>
     </springProfile>

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
+        <http>
+            <url>http://localhost:3100/loki/api/v1/push</url>
+        </http>
+        <format>
+            <label>
+                <pattern>app=Pengcook,host=${HOSTNAME},level=%level</pattern>
+                <readMarkers>true</readMarkers>
+            </label>
+            <message>
+                <pattern>
+                    {
+                    "level":"%level",
+                    "class":"%logger{36}",
+                    "thread":"%thread",
+                    "message": "%message",
+                    "requestId": "%X{X-Request-ID}"
+                    }
+                </pattern>
+            </message>
+        </format>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="LOKI" />
+    </root>
+</configuration>


### PR DESCRIPTION
https://www.baeldung.com/spring-boot-loki-grafana-logging
해당 사이트를 참고하여 그라파나와 로키를 추가하여 로깅에 대한 부분만 모니터링을 추가하였습니다.

매트릭에 대한 정보는 추후 새로운 이슈에서 추가할 것이며 아마 프로메테우스를 사용하여 그라파나로 연결할 것 같습니다.

- **Grafana** 데이터 시각화
- **Loki** 로그 데이터 수집
- **Prometheus** 매트릭 데이터 수집

Spring Boot 는 자신에게 발생하는 로그들을  Loki에게 API 요청을 하여 데이터를 추가합니다.
추가된 데이터를 Grafana 가 Loki에게서 읽은 뒤 `label` 에 따라 검색할 수 있도록 해줍니다.