### PR TITLE
✨ add metric monitoring dashboard

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -29,11 +29,13 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5'
 	implementation 'com.google.firebase:firebase-admin:9.3.0'
 	implementation 'com.auth0:java-jwt:4.4.0'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 	implementation 'com.github.loki4j:loki-logback-appender:1.5.1'
+	implementation 'io.micrometer:micrometer-registry-prometheus'
 
 	runtimeOnly 'mysql:mysql-connector-java:8.0.33'
 	runtimeOnly 'com.h2database:h2'

--- a/backend/src/main/resources/application-dev.yaml
+++ b/backend/src/main/resources/application-dev.yaml
@@ -26,3 +26,12 @@ cloud:
       cloudfront-url: ENC(iiXL7OqsrKOHtg/V1STwsxeVZ32c5aVHfbTg/sYxLOPxhxdnOrzU2zGohfrzEty2q74q88gEqS0+cUhH2jIIu1+9ZzbBlRizNEGBr180icM=)
     region:
       static: ENC(a7sCLLXDx5Fn76E+NLdyxLoL3MEp6x1J/OcoFyg0ejxLrGAQ/O+82ZoDr6LXcRAt)
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: '*'
+  endpoint:
+    health:
+      show-details: always

--- a/backend/src/main/resources/application-local.yaml
+++ b/backend/src/main/resources/application-local.yaml
@@ -31,3 +31,12 @@ cloud:
       cloudfront-url: ENC(IsdQvQFcMFygCGIL76tqMxwmjKrwmANRzQWsX8kqbNb1l81Nbx8q1k910t+DvHUBgKTdTJkfs/ZMPIEuDAksb7BG6zY0+TTTLaPM0Bh0NoE=)
     region:
       static: ENC(+TXuroM2fUTZ5CpylDnJfO672+ZFCdA+AVKRDLKoCWKJm+0gQ8/GH+QtS7jLG2v9)
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: '*'
+  endpoint:
+    health:
+      show-details: always

--- a/backend/src/main/resources/docker-compose-dev.yaml
+++ b/backend/src/main/resources/docker-compose-dev.yaml
@@ -1,5 +1,6 @@
 volumes:
   db:
+  prometheus:
 
 services:
   db:
@@ -30,6 +31,26 @@ services:
     image: grafana/loki
     command: -config.file=/etc/loki/local-config.yaml
 
+  prometheus:
+    image: prom/prometheus
+    volumes:
+      - prometheus:/prometheus
+    entrypoint:
+      - sh
+      - -euc
+      - |
+        cat <<EOF > /prometheus/prometheus.yml
+        scrape_configs:
+          - job_name: 'pengcook'
+            metrics_path: '/actuator/prometheus'
+            scrape_interval: 15s
+            static_configs:
+              - targets: ['app:8080']
+        EOF
+        /bin/prometheus
+    links:
+      - app
+
   grafana:
     environment:
       - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
@@ -52,6 +73,15 @@ services:
           isDefault: true
           version: 1
           editable: false
+
+        - name: Prometheus
+          type: prometheus
+          access: proxy
+          orgId: 1
+          url: http://prometheus:9090
+          basicAuth: false
+          isDefault: false
+          editable: false
         EOF
         /run.sh
     image: grafana/grafana
@@ -59,3 +89,4 @@ services:
       - 3000:3000
     links:
       - loki
+      - prometheus

--- a/backend/src/main/resources/docker-compose-local.yaml
+++ b/backend/src/main/resources/docker-compose-local.yaml
@@ -1,5 +1,6 @@
 volumes:
   db:
+  prometheus:
 
 services:
   db:
@@ -23,6 +24,26 @@ services:
       - 3100:3100
     command: -config.file=/etc/loki/local-config.yaml
 
+  prometheus:
+    image: prom/prometheus
+    volumes:
+      - prometheus:/prometheus
+    ports:
+      - 9090:9090
+    entrypoint:
+      - sh
+      - -euc
+      - |
+        cat <<EOF > /prometheus/prometheus.yml
+        scrape_configs:
+          - job_name: 'pengcook'
+            metrics_path: '/actuator/prometheus'
+            scrape_interval: 15s
+            static_configs:
+              - targets: ['host.docker.internal:8080']
+        EOF
+        /bin/prometheus
+
   grafana:
     environment:
       - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
@@ -44,6 +65,15 @@ services:
           basicAuth: false
           isDefault: true
           version: 1
+          editable: false
+
+        - name: Prometheus
+          type: prometheus
+          access: proxy
+          orgId: 1
+          url: http://prometheus:9090
+          basicAuth: false
+          isDefault: false
           editable: false
         EOF
         /run.sh


### PR DESCRIPTION
- 기존 `Grafana` 와 `Loki` 의 로그 모니터링 도구에 `Prometheus` 라는 매트릭 수집기를 추가함
- `Prometheus` 컨테이너는 `Spring Boot` 인 `app` 컨테이너로 15초 마다 `/actuator/prometheus` 로 `GET` 요청을 하여 정보를 들고와 데이터를 수집함
- `Grafana` 에서는 `Prometheus` 를 데이터 소스로 설정하여 매트릭 데이터를 시각화 하여 보여줌