### PR TITLE
🐛 show log on console

### DIFF
--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
     <springProfile name="local">
         <property name="LOKI_URL" value="http://localhost:3100/loki/api/v1/push"/>
     </springProfile>
-
     <springProfile name="test">
         <property name="LOKI_URL" value="http://localhost:3100/loki/api/v1/push"/>
     </springProfile>
-
     <springProfile name="dev">
         <property name="LOKI_URL" value="http://loki:3100/loki/api/v1/push"/>
     </springProfile>
@@ -35,7 +35,14 @@
         </format>
     </appender>
 
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
     <root level="INFO">
         <appender-ref ref="LOKI"/>
+        <appender-ref ref="CONSOLE"/>
     </root>
 </configuration>


### PR DESCRIPTION
`Loki` 적용 이후 콘솔에 로그가 보이지 않던 버그를 수정하였습니다.

https://stackoverflow.com/questions/30571319/spring-boot-logging-pattern
위 링크를 참고하여 `Spring Boot Logback` 의 기본 패턴을 그대로 사용할 수 있었습니다!