### PR TITLE
✨ implement recipe and recipe steps creation

### DIFF
--- a/backend/src/main/java/net/pengcook/recipe/controller/RecipeController.java
+++ b/backend/src/main/java/net/pengcook/recipe/controller/RecipeController.java
@@ -40,9 +40,9 @@ public class RecipeController {
         return recipeService.createRecipe(userInfo, recipeRequest);
     }
 
-    @GetMapping("/{id}/steps")
-    public List<RecipeStepResponse> readRecipeSteps(@PathVariable long id) {
-        return recipeService.readRecipeSteps(id);
+    @GetMapping("/{recipeId}/steps")
+    public List<RecipeStepResponse> readRecipeSteps(@PathVariable long recipeId) {
+        return recipeService.readRecipeSteps(recipeId);
     }
 
     @GetMapping("/{recipeId}/steps/{sequence}")
@@ -52,13 +52,17 @@ public class RecipeController {
 
     @PostMapping("/{recipeId}/steps")
     @ResponseStatus(HttpStatus.CREATED)
-    public RecipeStepResponse createRecipeStep(@PathVariable long recipeId,
-                                               @RequestBody RecipeStepRequest recipeStepRequest) {
+    public RecipeStepResponse createRecipeStep(
+            @PathVariable long recipeId,
+            @RequestBody RecipeStepRequest recipeStepRequest
+    ) {
         return recipeService.createRecipeStep(recipeId, recipeStepRequest);
     }
 
     @GetMapping("/search")
-    public List<MainRecipeResponse> readRecipesOfCategory(@ModelAttribute RecipeOfCategoryRequest request) {
-        return recipeService.readRecipesOfCategory(request);
+    public List<MainRecipeResponse> readRecipesOfCategory(
+            @ModelAttribute RecipeOfCategoryRequest recipeOfCategoryRequest
+    ) {
+        return recipeService.readRecipesOfCategory(recipeOfCategoryRequest);
     }
 }

--- a/backend/src/main/java/net/pengcook/recipe/controller/RecipeController.java
+++ b/backend/src/main/java/net/pengcook/recipe/controller/RecipeController.java
@@ -2,13 +2,19 @@ package net.pengcook.recipe.controller;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import net.pengcook.authentication.domain.UserInfo;
+import net.pengcook.authentication.resolver.LoginUser;
 import net.pengcook.category.dto.RecipeOfCategoryRequest;
 import net.pengcook.recipe.dto.MainRecipeResponse;
+import net.pengcook.recipe.dto.RecipeRequest;
+import net.pengcook.recipe.dto.RecipeResponse;
 import net.pengcook.recipe.dto.RecipeStepResponse;
 import net.pengcook.recipe.service.RecipeService;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -23,6 +29,11 @@ public class RecipeController {
     @GetMapping
     public List<MainRecipeResponse> readRecipes(@RequestParam int pageNumber, @RequestParam int pageSize) {
         return recipeService.readRecipes(pageNumber, pageSize);
+    }
+
+    @PostMapping
+    public RecipeResponse createRecipe(@LoginUser UserInfo userInfo, @RequestBody RecipeRequest recipeRequest) {
+        return recipeService.createRecipe(userInfo, recipeRequest);
     }
 
     @GetMapping("/{id}/steps")

--- a/backend/src/main/java/net/pengcook/recipe/controller/RecipeController.java
+++ b/backend/src/main/java/net/pengcook/recipe/controller/RecipeController.java
@@ -11,6 +11,7 @@ import net.pengcook.recipe.dto.RecipeResponse;
 import net.pengcook.recipe.dto.RecipeStepRequest;
 import net.pengcook.recipe.dto.RecipeStepResponse;
 import net.pengcook.recipe.service.RecipeService;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -33,6 +35,7 @@ public class RecipeController {
     }
 
     @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
     public RecipeResponse createRecipe(@LoginUser UserInfo userInfo, @RequestBody RecipeRequest recipeRequest) {
         return recipeService.createRecipe(userInfo, recipeRequest);
     }
@@ -48,6 +51,7 @@ public class RecipeController {
     }
 
     @PostMapping("/{recipeId}/steps")
+    @ResponseStatus(HttpStatus.CREATED)
     public RecipeStepResponse createRecipeStep(@PathVariable long recipeId,
                                                @RequestBody RecipeStepRequest recipeStepRequest) {
         return recipeService.createRecipeStep(recipeId, recipeStepRequest);

--- a/backend/src/main/java/net/pengcook/recipe/controller/RecipeController.java
+++ b/backend/src/main/java/net/pengcook/recipe/controller/RecipeController.java
@@ -42,6 +42,11 @@ public class RecipeController {
         return recipeService.readRecipeSteps(id);
     }
 
+    @GetMapping("/{recipeId}/steps/{sequence}")
+    public RecipeStepResponse readRecipeStep(@PathVariable long recipeId, @PathVariable long sequence) {
+        return recipeService.readRecipeStep(recipeId, sequence);
+    }
+
     @PostMapping("/{recipeId}/steps")
     public RecipeStepResponse createRecipeStep(@PathVariable long recipeId,
                                                @RequestBody RecipeStepRequest recipeStepRequest) {

--- a/backend/src/main/java/net/pengcook/recipe/controller/RecipeController.java
+++ b/backend/src/main/java/net/pengcook/recipe/controller/RecipeController.java
@@ -8,6 +8,7 @@ import net.pengcook.category.dto.RecipeOfCategoryRequest;
 import net.pengcook.recipe.dto.MainRecipeResponse;
 import net.pengcook.recipe.dto.RecipeRequest;
 import net.pengcook.recipe.dto.RecipeResponse;
+import net.pengcook.recipe.dto.RecipeStepRequest;
 import net.pengcook.recipe.dto.RecipeStepResponse;
 import net.pengcook.recipe.service.RecipeService;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -39,6 +40,12 @@ public class RecipeController {
     @GetMapping("/{id}/steps")
     public List<RecipeStepResponse> readRecipeSteps(@PathVariable long id) {
         return recipeService.readRecipeSteps(id);
+    }
+
+    @PostMapping("/{recipeId}/steps")
+    public RecipeStepResponse createRecipeStep(@PathVariable long recipeId,
+                                               @RequestBody RecipeStepRequest recipeStepRequest) {
+        return recipeService.createRecipeStep(recipeId, recipeStepRequest);
     }
 
     @GetMapping("/search")

--- a/backend/src/main/java/net/pengcook/recipe/domain/Recipe.java
+++ b/backend/src/main/java/net/pengcook/recipe/domain/Recipe.java
@@ -45,4 +45,16 @@ public class Recipe {
 
     @Column(nullable = true)
     private String description;
+
+    public Recipe(
+            String title,
+            User author,
+            LocalTime cookingTime,
+            String thumbnail,
+            int difficulty,
+            int likeCount,
+            String description
+    ) {
+        this(0L, title, author, cookingTime, thumbnail, difficulty, likeCount, description);
+    }
 }

--- a/backend/src/main/java/net/pengcook/recipe/domain/Recipe.java
+++ b/backend/src/main/java/net/pengcook/recipe/domain/Recipe.java
@@ -52,9 +52,8 @@ public class Recipe {
             LocalTime cookingTime,
             String thumbnail,
             int difficulty,
-            int likeCount,
             String description
     ) {
-        this(0L, title, author, cookingTime, thumbnail, difficulty, likeCount, description);
+        this(0L, title, author, cookingTime, thumbnail, difficulty, 0, description);
     }
 }

--- a/backend/src/main/java/net/pengcook/recipe/domain/RecipeStep.java
+++ b/backend/src/main/java/net/pengcook/recipe/domain/RecipeStep.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.time.LocalTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -31,7 +32,13 @@ public class RecipeStep {
 
     private int sequence;
 
+    private LocalTime cookingTime;
+
     public long recipeId() {
         return recipe.getId();
+    }
+
+    public RecipeStep(Recipe recipe, String image, String description, int sequence, LocalTime cookingTime) {
+        this(0L, recipe, image, description, sequence, cookingTime);
     }
 }

--- a/backend/src/main/java/net/pengcook/recipe/domain/RecipeStep.java
+++ b/backend/src/main/java/net/pengcook/recipe/domain/RecipeStep.java
@@ -34,11 +34,11 @@ public class RecipeStep {
 
     private LocalTime cookingTime;
 
-    public long recipeId() {
-        return recipe.getId();
-    }
-
     public RecipeStep(Recipe recipe, String image, String description, int sequence, LocalTime cookingTime) {
         this(0L, recipe, image, description, sequence, cookingTime);
+    }
+
+    public long recipeId() {
+        return recipe.getId();
     }
 }

--- a/backend/src/main/java/net/pengcook/recipe/dto/RecipeRequest.java
+++ b/backend/src/main/java/net/pengcook/recipe/dto/RecipeRequest.java
@@ -7,7 +7,7 @@ import net.pengcook.ingredient.dto.IngredientCreateRequest;
 
 public record RecipeRequest(
         String title,
-        LocalTime cookingTime,
+        String cookingTime,
         String thumbnail,
         int difficulty,
         String description,

--- a/backend/src/main/java/net/pengcook/recipe/dto/RecipeRequest.java
+++ b/backend/src/main/java/net/pengcook/recipe/dto/RecipeRequest.java
@@ -1,7 +1,5 @@
 package net.pengcook.recipe.dto;
 
-import jakarta.annotation.Nullable;
-import java.time.LocalTime;
 import java.util.List;
 import net.pengcook.ingredient.dto.IngredientCreateRequest;
 

--- a/backend/src/main/java/net/pengcook/recipe/dto/RecipeRequest.java
+++ b/backend/src/main/java/net/pengcook/recipe/dto/RecipeRequest.java
@@ -1,0 +1,18 @@
+package net.pengcook.recipe.dto;
+
+import jakarta.annotation.Nullable;
+import java.time.LocalTime;
+import java.util.List;
+import net.pengcook.ingredient.dto.IngredientCreateRequest;
+
+public record RecipeRequest(
+        String title,
+        LocalTime cookingTime,
+        String thumbnail,
+        int difficulty,
+        int likeCount,
+        String description,
+        List<String> categories,
+        List<IngredientCreateRequest> ingredients
+) {
+}

--- a/backend/src/main/java/net/pengcook/recipe/dto/RecipeRequest.java
+++ b/backend/src/main/java/net/pengcook/recipe/dto/RecipeRequest.java
@@ -10,7 +10,6 @@ public record RecipeRequest(
         LocalTime cookingTime,
         String thumbnail,
         int difficulty,
-        int likeCount,
         String description,
         List<String> categories,
         List<IngredientCreateRequest> ingredients

--- a/backend/src/main/java/net/pengcook/recipe/dto/RecipeRequest.java
+++ b/backend/src/main/java/net/pengcook/recipe/dto/RecipeRequest.java
@@ -1,15 +1,16 @@
 package net.pengcook.recipe.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import java.util.List;
 import net.pengcook.ingredient.dto.IngredientCreateRequest;
 
 public record RecipeRequest(
-        String title,
-        String cookingTime,
-        String thumbnail,
-        int difficulty,
-        String description,
-        List<String> categories,
-        List<IngredientCreateRequest> ingredients
+        @NotBlank String title,
+        @NotBlank String cookingTime,
+        @NotBlank String thumbnail,
+        @NotBlank int difficulty,
+        @NotBlank String description,
+        @NotBlank List<String> categories,
+        @NotBlank List<IngredientCreateRequest> ingredients
 ) {
 }

--- a/backend/src/main/java/net/pengcook/recipe/dto/RecipeResponse.java
+++ b/backend/src/main/java/net/pengcook/recipe/dto/RecipeResponse.java
@@ -1,0 +1,10 @@
+package net.pengcook.recipe.dto;
+
+import net.pengcook.recipe.domain.Recipe;
+
+public record RecipeResponse(long recipeId) {
+
+    public RecipeResponse(Recipe savedRecipe) {
+        this(savedRecipe.getId());
+    }
+}

--- a/backend/src/main/java/net/pengcook/recipe/dto/RecipeStepRequest.java
+++ b/backend/src/main/java/net/pengcook/recipe/dto/RecipeStepRequest.java
@@ -1,0 +1,6 @@
+package net.pengcook.recipe.dto;
+
+import java.time.LocalTime;
+
+public record RecipeStepRequest(String image, String description, int sequence, LocalTime cookingTime) {
+}

--- a/backend/src/main/java/net/pengcook/recipe/dto/RecipeStepRequest.java
+++ b/backend/src/main/java/net/pengcook/recipe/dto/RecipeStepRequest.java
@@ -1,4 +1,12 @@
 package net.pengcook.recipe.dto;
 
-public record RecipeStepRequest(String image, String description, int sequence, String cookingTime) {
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+
+public record RecipeStepRequest(
+        String image,
+        @NotBlank String description,
+        @Positive int sequence,
+        @NotBlank String cookingTime
+) {
 }

--- a/backend/src/main/java/net/pengcook/recipe/dto/RecipeStepRequest.java
+++ b/backend/src/main/java/net/pengcook/recipe/dto/RecipeStepRequest.java
@@ -1,6 +1,4 @@
 package net.pengcook.recipe.dto;
 
-import java.time.LocalTime;
-
-public record RecipeStepRequest(String image, String description, int sequence, LocalTime cookingTime) {
+public record RecipeStepRequest(String image, String description, int sequence, String cookingTime) {
 }

--- a/backend/src/main/java/net/pengcook/recipe/exception/NotFoundException.java
+++ b/backend/src/main/java/net/pengcook/recipe/exception/NotFoundException.java
@@ -1,0 +1,10 @@
+package net.pengcook.recipe.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class NotFoundException extends RecipeException {
+
+    public NotFoundException(String message) {
+        super(HttpStatus.NOT_FOUND, message);
+    }
+}

--- a/backend/src/main/java/net/pengcook/recipe/repository/RecipeStepRepository.java
+++ b/backend/src/main/java/net/pengcook/recipe/repository/RecipeStepRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RecipeStepRepository extends JpaRepository<RecipeStep, Long> {
 
-    List<RecipeStep> findAllByRecipeIdOrderBySequence(long id);
+    List<RecipeStep> findAllByRecipeIdOrderBySequence(long recipeId);
 
     Optional<RecipeStep> findByRecipeIdAndSequence(long recipeId, long sequence);
 }

--- a/backend/src/main/java/net/pengcook/recipe/repository/RecipeStepRepository.java
+++ b/backend/src/main/java/net/pengcook/recipe/repository/RecipeStepRepository.java
@@ -1,10 +1,13 @@
 package net.pengcook.recipe.repository;
 
 import java.util.List;
+import java.util.Optional;
 import net.pengcook.recipe.domain.RecipeStep;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RecipeStepRepository extends JpaRepository<RecipeStep, Long> {
 
     List<RecipeStep> findAllByRecipeIdOrderBySequence(long id);
+
+    Optional<RecipeStep> findByRecipeIdAndSequence(long recipeId, long sequence);
 }

--- a/backend/src/main/java/net/pengcook/recipe/service/RecipeService.java
+++ b/backend/src/main/java/net/pengcook/recipe/service/RecipeService.java
@@ -31,8 +31,10 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class RecipeService {
 

--- a/backend/src/main/java/net/pengcook/recipe/service/RecipeService.java
+++ b/backend/src/main/java/net/pengcook/recipe/service/RecipeService.java
@@ -19,13 +19,16 @@ import net.pengcook.recipe.dto.MainRecipeResponse;
 import net.pengcook.recipe.dto.RecipeDataResponse;
 import net.pengcook.recipe.dto.RecipeRequest;
 import net.pengcook.recipe.dto.RecipeResponse;
+import net.pengcook.recipe.dto.RecipeStepRequest;
 import net.pengcook.recipe.dto.RecipeStepResponse;
+import net.pengcook.recipe.exception.RecipeException;
 import net.pengcook.recipe.repository.RecipeRepository;
 import net.pengcook.recipe.repository.RecipeStepRepository;
 import net.pengcook.user.domain.User;
 import net.pengcook.user.repository.UserRepository;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -64,6 +67,18 @@ public class RecipeService {
     public List<RecipeStepResponse> readRecipeSteps(long id) {
         List<RecipeStep> recipeSteps = recipeStepRepository.findAllByRecipeIdOrderBySequence(id);
         return convertToRecipeStepResponses(recipeSteps);
+    }
+
+    public RecipeStepResponse createRecipeStep(long recipeId, RecipeStepRequest recipeStepRequest) {
+        Recipe recipe = recipeRepository.findById(recipeId)
+                .orElseThrow(() -> new RecipeException(HttpStatus.NO_CONTENT, "해당되는 레시피가 없습니다."));
+
+        RecipeStep recipeStep = new RecipeStep(recipe, recipeStepRequest.image(), recipeStepRequest.description(),
+                recipeStepRequest.sequence(), recipeStepRequest.cookingTime());
+
+        RecipeStep savedRecipeStep = recipeStepRepository.save(recipeStep);
+
+        return new RecipeStepResponse(savedRecipeStep);
     }
 
     public List<MainRecipeResponse> readRecipesOfCategory(RecipeOfCategoryRequest request) {

--- a/backend/src/main/java/net/pengcook/recipe/service/RecipeService.java
+++ b/backend/src/main/java/net/pengcook/recipe/service/RecipeService.java
@@ -1,5 +1,6 @@
 package net.pengcook.recipe.service;
 
+import java.time.LocalTime;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
@@ -53,7 +54,7 @@ public class RecipeService {
 
     public RecipeResponse createRecipe(UserInfo userInfo, RecipeRequest recipeRequest) {
         User author = userRepository.findById(userInfo.getId()).orElseThrow();
-        Recipe recipe = new Recipe(recipeRequest.title(), author, recipeRequest.cookingTime(),
+        Recipe recipe = new Recipe(recipeRequest.title(), author, LocalTime.parse(recipeRequest.cookingTime()),
                 recipeRequest.thumbnail(), recipeRequest.difficulty(), recipeRequest.description());
 
         Recipe savedRecipe = recipeRepository.save(recipe);
@@ -80,7 +81,7 @@ public class RecipeService {
                 .orElseThrow(() -> new RecipeException(HttpStatus.NO_CONTENT, "해당되는 레시피가 없습니다."));
 
         RecipeStep recipeStep = new RecipeStep(recipe, recipeStepRequest.image(), recipeStepRequest.description(),
-                recipeStepRequest.sequence(), recipeStepRequest.cookingTime());
+                recipeStepRequest.sequence(), LocalTime.parse(recipeStepRequest.cookingTime()));
 
         RecipeStep savedRecipeStep = recipeStepRepository.save(recipeStep);
 

--- a/backend/src/main/java/net/pengcook/recipe/service/RecipeService.java
+++ b/backend/src/main/java/net/pengcook/recipe/service/RecipeService.java
@@ -55,8 +55,14 @@ public class RecipeService {
 
     public RecipeResponse createRecipe(UserInfo userInfo, RecipeRequest recipeRequest) {
         User author = userRepository.findById(userInfo.getId()).orElseThrow();
-        Recipe recipe = new Recipe(recipeRequest.title(), author, LocalTime.parse(recipeRequest.cookingTime()),
-                recipeRequest.thumbnail(), recipeRequest.difficulty(), recipeRequest.description());
+        Recipe recipe = new Recipe(
+                recipeRequest.title(),
+                author,
+                LocalTime.parse(recipeRequest.cookingTime()),
+                recipeRequest.thumbnail(),
+                recipeRequest.difficulty(),
+                recipeRequest.description()
+        );
 
         Recipe savedRecipe = recipeRepository.save(recipe);
         categoryService.saveCategories(savedRecipe, recipeRequest.categories());
@@ -65,8 +71,8 @@ public class RecipeService {
         return new RecipeResponse(savedRecipe);
     }
 
-    public List<RecipeStepResponse> readRecipeSteps(long id) {
-        List<RecipeStep> recipeSteps = recipeStepRepository.findAllByRecipeIdOrderBySequence(id);
+    public List<RecipeStepResponse> readRecipeSteps(long recipeId) {
+        List<RecipeStep> recipeSteps = recipeStepRepository.findAllByRecipeIdOrderBySequence(recipeId);
         return convertToRecipeStepResponses(recipeSteps);
     }
 
@@ -81,11 +87,15 @@ public class RecipeService {
         Recipe recipe = recipeRepository.findById(recipeId)
                 .orElseThrow(() -> new NotFoundException("해당되는 레시피가 없습니다."));
 
-        RecipeStep recipeStep = new RecipeStep(recipe, recipeStepRequest.image(), recipeStepRequest.description(),
-                recipeStepRequest.sequence(), LocalTime.parse(recipeStepRequest.cookingTime()));
+        RecipeStep recipeStep = new RecipeStep(
+                recipe,
+                recipeStepRequest.image(),
+                recipeStepRequest.description(),
+                recipeStepRequest.sequence(),
+                LocalTime.parse(recipeStepRequest.cookingTime())
+        );
 
         RecipeStep savedRecipeStep = recipeStepRepository.save(recipeStep);
-
         return new RecipeStepResponse(savedRecipeStep);
     }
 

--- a/backend/src/main/java/net/pengcook/recipe/service/RecipeService.java
+++ b/backend/src/main/java/net/pengcook/recipe/service/RecipeService.java
@@ -69,6 +69,13 @@ public class RecipeService {
         return convertToRecipeStepResponses(recipeSteps);
     }
 
+    public RecipeStepResponse readRecipeStep(long recipeId, long sequence) {
+        RecipeStep recipeStep = recipeStepRepository.findByRecipeIdAndSequence(recipeId, sequence)
+                .orElseThrow(() -> new RecipeException(HttpStatus.NO_CONTENT, "해당되는 레시피 스텝 정보가 없습니다."));
+
+        return new RecipeStepResponse(recipeStep);
+    }
+
     public RecipeStepResponse createRecipeStep(long recipeId, RecipeStepRequest recipeStepRequest) {
         Recipe recipe = recipeRepository.findById(recipeId)
                 .orElseThrow(() -> new RecipeException(HttpStatus.NO_CONTENT, "해당되는 레시피가 없습니다."));

--- a/backend/src/main/java/net/pengcook/recipe/service/RecipeService.java
+++ b/backend/src/main/java/net/pengcook/recipe/service/RecipeService.java
@@ -22,14 +22,13 @@ import net.pengcook.recipe.dto.RecipeRequest;
 import net.pengcook.recipe.dto.RecipeResponse;
 import net.pengcook.recipe.dto.RecipeStepRequest;
 import net.pengcook.recipe.dto.RecipeStepResponse;
-import net.pengcook.recipe.exception.RecipeException;
+import net.pengcook.recipe.exception.NotFoundException;
 import net.pengcook.recipe.repository.RecipeRepository;
 import net.pengcook.recipe.repository.RecipeStepRepository;
 import net.pengcook.user.domain.User;
 import net.pengcook.user.repository.UserRepository;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -73,14 +72,14 @@ public class RecipeService {
 
     public RecipeStepResponse readRecipeStep(long recipeId, long sequence) {
         RecipeStep recipeStep = recipeStepRepository.findByRecipeIdAndSequence(recipeId, sequence)
-                .orElseThrow(() -> new RecipeException(HttpStatus.NO_CONTENT, "해당되는 레시피 스텝 정보가 없습니다."));
+                .orElseThrow(() -> new NotFoundException("해당되는 레시피 스텝 정보가 없습니다."));
 
         return new RecipeStepResponse(recipeStep);
     }
 
     public RecipeStepResponse createRecipeStep(long recipeId, RecipeStepRequest recipeStepRequest) {
         Recipe recipe = recipeRepository.findById(recipeId)
-                .orElseThrow(() -> new RecipeException(HttpStatus.NO_CONTENT, "해당되는 레시피가 없습니다."));
+                .orElseThrow(() -> new NotFoundException("해당되는 레시피가 없습니다."));
 
         RecipeStep recipeStep = new RecipeStep(recipe, recipeStepRequest.image(), recipeStepRequest.description(),
                 recipeStepRequest.sequence(), LocalTime.parse(recipeStepRequest.cookingTime()));

--- a/backend/src/main/java/net/pengcook/recipe/service/RecipeService.java
+++ b/backend/src/main/java/net/pengcook/recipe/service/RecipeService.java
@@ -54,8 +54,7 @@ public class RecipeService {
     public RecipeResponse createRecipe(UserInfo userInfo, RecipeRequest recipeRequest) {
         User author = userRepository.findById(userInfo.getId()).orElseThrow();
         Recipe recipe = new Recipe(recipeRequest.title(), author, recipeRequest.cookingTime(),
-                recipeRequest.thumbnail(),
-                recipeRequest.difficulty(), recipeRequest.likeCount(), recipeRequest.description());
+                recipeRequest.thumbnail(), recipeRequest.difficulty(), recipeRequest.description());
 
         Recipe savedRecipe = recipeRepository.save(recipe);
         categoryService.saveCategories(savedRecipe, recipeRequest.categories());

--- a/backend/src/test/java/net/pengcook/category/service/CategoryServiceTest.java
+++ b/backend/src/test/java/net/pengcook/category/service/CategoryServiceTest.java
@@ -18,7 +18,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.jdbc.Sql;
 
 @DataJpaTest
-@Import({CategoryService.class, RecipeService.class})
+@Import(CategoryService.class)
 @Sql(scripts = "/data/category.sql")
 class CategoryServiceTest {
 

--- a/backend/src/test/java/net/pengcook/recipe/controller/RecipeControllerTest.java
+++ b/backend/src/test/java/net/pengcook/recipe/controller/RecipeControllerTest.java
@@ -121,7 +121,7 @@ class RecipeControllerTest extends RestDocsSetting {
                         "특정 레시피의 상세 스텝을 조회합니다.",
                         "레시피 상세 스텝 조회 API",
                         pathParameters(
-                                parameterWithName("id").description("레시피 아이디")
+                                parameterWithName("recipeId").description("레시피 아이디")
                         ),
                         responseFields(
                                 fieldWithPath("[]").description("레시피 스텝 목록"),
@@ -132,7 +132,7 @@ class RecipeControllerTest extends RestDocsSetting {
                                 fieldWithPath("[].sequence").description("레시피 스텝 순서")
                         )))
                 .when()
-                .get("/api/recipes/{id}/steps", 1L)
+                .get("/api/recipes/{recipeId}/steps", 1L)
                 .then().log().all()
                 .body("size()", is(3));
     }

--- a/backend/src/test/java/net/pengcook/recipe/controller/RecipeControllerTest.java
+++ b/backend/src/test/java/net/pengcook/recipe/controller/RecipeControllerTest.java
@@ -137,6 +137,31 @@ class RecipeControllerTest extends RestDocsSetting {
     }
 
     @Test
+    @DisplayName("특정 레시피의 특정 스텝을 조회한다.")
+    void readRecipeStep() {
+        RestAssured.given(spec).log().all()
+                .filter(document(DEFAULT_RESTDOCS_PATH,
+                        "특정 레시피의 특정 스텝을 조회합니다.",
+                        "특정 레시피 특정 스텝 조회 API",
+                        pathParameters(
+                                parameterWithName("recipeId").description("조회할 레시피 아이디"),
+                                parameterWithName("sequence").description("조회할 스텝 순서")
+                        ),
+                        responseFields(
+                                fieldWithPath("id").description("레시피 스텝 아이디"),
+                                fieldWithPath("recipeId").description("레시피 아이디"),
+                                fieldWithPath("image").description("레시피 스텝 이미지"),
+                                fieldWithPath("description").description("레시피 스텝 설명"),
+                                fieldWithPath("sequence").description("레시피 스텝 순서")
+                        )))
+                .when()
+                .get("/api/recipes/{recipeId}/steps/{sequence}", 1L, 1L)
+                .then().log().all()
+                .statusCode(200)
+                .body("description", is("레시피1 설명1"));
+    }
+
+    @Test
     @DisplayName("카테고리별 레시피 개요 목록을 조회한다.")
     void readRecipesOfCategory() {
         RestAssured.given(spec).log().all()

--- a/backend/src/test/java/net/pengcook/recipe/controller/RecipeControllerTest.java
+++ b/backend/src/test/java/net/pengcook/recipe/controller/RecipeControllerTest.java
@@ -18,6 +18,7 @@ import net.pengcook.authentication.annotation.WithLoginUserTest;
 import net.pengcook.ingredient.domain.Requirement;
 import net.pengcook.ingredient.dto.IngredientCreateRequest;
 import net.pengcook.recipe.dto.RecipeRequest;
+import net.pengcook.recipe.dto.RecipeStepRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.jdbc.Sql;
@@ -159,6 +160,39 @@ class RecipeControllerTest extends RestDocsSetting {
                 .then().log().all()
                 .statusCode(200)
                 .body("description", is("레시피1 설명1"));
+    }
+
+    @Test
+    @DisplayName("특정 레시피의 레시피 스텝을 생성한다.")
+    void createRecipeStep() {
+        RecipeStepRequest recipeStepRequest = new RecipeStepRequest("신규 스텝 이미지.jpg", "신규 스텝 설명", 4, "00:05:00");
+
+        RestAssured.given(spec).log().all()
+                .filter(document(DEFAULT_RESTDOCS_PATH,
+                        "특정 레시피의 레시피 스텝을 생성합니다.",
+                        "특정 레시피 레시피 스텝 생성 API",
+                        pathParameters(
+                                parameterWithName("recipeId").description("레시피 스텝을 추가할 레시피 아이디")
+                        ),
+                        requestFields(
+                                fieldWithPath("image").description("레시피 스텝 이미지"),
+                                fieldWithPath("description").description("레시피 스텝 설명"),
+                                fieldWithPath("sequence").description("레시피 스텝 순서"),
+                                fieldWithPath("cookingTime").description("레시피 스텝 소요시간")
+                        ),
+                        responseFields(
+                                fieldWithPath("id").description("레시피 스텝 아이디"),
+                                fieldWithPath("recipeId").description("레시피 아이디"),
+                                fieldWithPath("image").description("레시피 스텝 이미지"),
+                                fieldWithPath("description").description("레시피 스텝 설명"),
+                                fieldWithPath("sequence").description("레시피 스텝 순서")
+                        )))
+                .contentType(ContentType.JSON)
+                .body(recipeStepRequest)
+                .when()
+                .post("/api/recipes/{recipeId}/steps", 1L)
+                .then().log().all()
+                .statusCode(201);
     }
 
     @Test

--- a/backend/src/test/java/net/pengcook/recipe/service/RecipeServiceTest.java
+++ b/backend/src/test/java/net/pengcook/recipe/service/RecipeServiceTest.java
@@ -7,6 +7,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 import net.pengcook.category.dto.RecipeOfCategoryRequest;
+import net.pengcook.category.service.CategoryService;
+import net.pengcook.ingredient.service.IngredientRecipeService;
+import net.pengcook.ingredient.service.IngredientService;
+import net.pengcook.ingredient.service.IngredientSubstitutionService;
 import net.pengcook.recipe.dto.MainRecipeResponse;
 import net.pengcook.recipe.dto.RecipeStepResponse;
 import org.junit.jupiter.api.DisplayName;
@@ -21,7 +25,8 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.jdbc.Sql;
 
 @DataJpaTest
-@Import(RecipeService.class)
+@Import({RecipeService.class, CategoryService.class, IngredientService.class, IngredientRecipeService.class,
+        IngredientSubstitutionService.class})
 @Sql(value = "/data/recipe.sql")
 class RecipeServiceTest {
 

--- a/backend/src/test/java/net/pengcook/recipe/service/RecipeServiceTest.java
+++ b/backend/src/test/java/net/pengcook/recipe/service/RecipeServiceTest.java
@@ -8,12 +8,8 @@ import java.util.List;
 import java.util.stream.Stream;
 import net.pengcook.authentication.domain.UserInfo;
 import net.pengcook.category.dto.RecipeOfCategoryRequest;
-import net.pengcook.category.service.CategoryService;
 import net.pengcook.ingredient.domain.Requirement;
 import net.pengcook.ingredient.dto.IngredientCreateRequest;
-import net.pengcook.ingredient.service.IngredientRecipeService;
-import net.pengcook.ingredient.service.IngredientService;
-import net.pengcook.ingredient.service.IngredientSubstitutionService;
 import net.pengcook.recipe.dto.MainRecipeResponse;
 import net.pengcook.recipe.dto.RecipeRequest;
 import net.pengcook.recipe.dto.RecipeResponse;
@@ -26,13 +22,10 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.jdbc.Sql;
 
-@DataJpaTest
-@Import({RecipeService.class, CategoryService.class, IngredientService.class, IngredientRecipeService.class,
-        IngredientSubstitutionService.class})
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Sql(value = "/data/recipe.sql")
 class RecipeServiceTest {
 

--- a/backend/src/test/java/net/pengcook/recipe/service/RecipeServiceTest.java
+++ b/backend/src/test/java/net/pengcook/recipe/service/RecipeServiceTest.java
@@ -6,12 +6,18 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
+import net.pengcook.authentication.domain.UserInfo;
 import net.pengcook.category.dto.RecipeOfCategoryRequest;
 import net.pengcook.category.service.CategoryService;
+import net.pengcook.ingredient.domain.Requirement;
+import net.pengcook.ingredient.dto.IngredientCreateRequest;
 import net.pengcook.ingredient.service.IngredientRecipeService;
 import net.pengcook.ingredient.service.IngredientService;
 import net.pengcook.ingredient.service.IngredientSubstitutionService;
 import net.pengcook.recipe.dto.MainRecipeResponse;
+import net.pengcook.recipe.dto.RecipeRequest;
+import net.pengcook.recipe.dto.RecipeResponse;
+import net.pengcook.recipe.dto.RecipeStepRequest;
 import net.pengcook.recipe.dto.RecipeStepResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -43,6 +49,32 @@ class RecipeServiceTest {
     }
 
     @Test
+    @DisplayName("새로운 레시피를 생성한다.")
+    void createRecipe() {
+        UserInfo userInfo = new UserInfo(1L, "loki@pengcook.net");
+
+        List<String> categories = List.of("Dessert", "NewCategory");
+        List<String> substitutions = List.of("Water", "Orange");
+        List<IngredientCreateRequest> ingredients = List.of(
+                new IngredientCreateRequest("Apple", Requirement.REQUIRED, substitutions),
+                new IngredientCreateRequest("WaterMelon", Requirement.OPTIONAL, null)
+        );
+        RecipeRequest recipeRequest = new RecipeRequest(
+                "새로운 레시피 제목",
+                "00:30:00",
+                "레시피 썸네일.jpg",
+                4,
+                "새로운 레시피 설명",
+                categories,
+                ingredients
+        );
+
+        RecipeResponse recipe = recipeService.createRecipe(userInfo, recipeRequest);
+
+        assertThat(recipe.recipeId()).isEqualTo(16L);
+    }
+
+    @Test
     @DisplayName("특정 레시피의 스텝을 sequence 순서로 조회한다.")
     void readRecipeSteps() {
         long recipeId = 1L;
@@ -55,6 +87,31 @@ class RecipeServiceTest {
         List<RecipeStepResponse> recipeStepResponses = recipeService.readRecipeSteps(recipeId);
 
         assertThat(recipeStepResponses).isEqualTo(expectedRecipeStepResponses);
+    }
+
+    @Test
+    @DisplayName("특정 레시피의 특정 레시피 스텝을 조회한다.")
+    void readRecipeStep() {
+        RecipeStepResponse recipeStepResponse = recipeService.readRecipeStep(1L, 1L);
+
+        assertAll(
+                () -> assertThat(recipeStepResponse.recipeId()).isEqualTo(1L),
+                () -> assertThat(recipeStepResponse.description()).isEqualTo("레시피1 설명1")
+        );
+
+    }
+
+    @Test
+    @DisplayName("특정 레시피의 레시피 스텝을 생성한다.")
+    void createRecipeStep() {
+        RecipeStepRequest recipeStepRequest = new RecipeStepRequest("새로운 스텝 이미지.jpg", "새로운 스텝 설명", 1, "00:05:00");
+
+        RecipeStepResponse recipeStepResponse = recipeService.createRecipeStep(2L, recipeStepRequest);
+
+        assertAll(
+                () -> assertThat(recipeStepResponse.recipeId()).isEqualTo(2L),
+                () -> assertThat(recipeStepResponse.description()).isEqualTo("새로운 스텝 설명")
+        );
     }
 
     @ParameterizedTest


### PR DESCRIPTION
### 구현 API
(1) POST `/api/recipes`
(2) POST `/api/recipes/{recipeId}/steps`
(3) GET `/api/recipes/{recipeId}/steps/{sequence}`

### 참고 사항
- 레시피 생성 흐름은 다음과 같습니다.
Recipe 생성 요청(1) -> 생성된 Recipe의 id 응답 -> Recipe id와 함께 각 Recipe Step 생성 요청(2) -> 생성된 Recipe Step 정보 응답
레시피 생성 중 레시피 스텝 전/후로 이동하기 위해 Recipe id, sequence로 Step 조회하는 API(3) 가 추가되었습니다.

- 필드 수정
RecipeStep에 해당 Step의 소요시간 필드 추가

---

레시피 생성 하나의 이슈인데 레시피 생성을 위한 단계가 많아 코드 변경사항이 조금 있습니다.
`레시피 생성`, `레시피 스텝 생성`, `레시피의 스텝 조회` 각각의 흐름을 따라가며 보시면 좀 더 보기 편하실 것 같습니다.

중복 sequence 검증 등의 예외 처리는 되어있지 않습니다. 참고 부탁드리며 편하게 피드백 부탁드립니다!!! 🙇🏻‍♀️