### PR TITLE
:zap: set restart options on containers

### DIFF
--- a/backend/src/main/resources/docker-compose-dev.yaml
+++ b/backend/src/main/resources/docker-compose-dev.yaml
@@ -29,10 +29,12 @@ services:
 
   loki:
     image: grafana/loki
+    restart: unless-stopped
     command: -config.file=/etc/loki/local-config.yaml
 
   prometheus:
     image: prom/prometheus
+    restart: unless-stopped
     volumes:
       - prometheus:/prometheus
     entrypoint:
@@ -52,6 +54,8 @@ services:
       - app
 
   grafana:
+    image: grafana/grafana
+    restart: unless-stopped
     environment:
       - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
       - GF_AUTH_ANONYMOUS_ENABLED=true
@@ -84,7 +88,6 @@ services:
           editable: false
         EOF
         /run.sh
-    image: grafana/grafana
     ports:
       - 3000:3000
     links:

--- a/backend/src/main/resources/docker-compose-dev.yaml
+++ b/backend/src/main/resources/docker-compose-dev.yaml
@@ -1,5 +1,6 @@
 volumes:
   db:
+  grafana:
   prometheus:
 
 services:
@@ -56,6 +57,8 @@ services:
   grafana:
     image: grafana/grafana
     restart: unless-stopped
+    volumes:
+      - grafana:/var/lib/grafana
     environment:
       - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
       - GF_AUTH_ANONYMOUS_ENABLED=true

--- a/backend/src/main/resources/docker-compose-local.yaml
+++ b/backend/src/main/resources/docker-compose-local.yaml
@@ -1,5 +1,6 @@
 volumes:
   db:
+  grafana:
   prometheus:
 
 services:
@@ -49,6 +50,8 @@ services:
   grafana:
     image: grafana/grafana
     restart: unless-stopped
+    volumes:
+      - grafana:/var/lib/grafana
     environment:
       - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
       - GF_AUTH_ANONYMOUS_ENABLED=true

--- a/backend/src/main/resources/docker-compose-local.yaml
+++ b/backend/src/main/resources/docker-compose-local.yaml
@@ -20,12 +20,14 @@ services:
 
   loki:
     image: grafana/loki
+    restart: unless-stopped
     ports:
       - 3100:3100
     command: -config.file=/etc/loki/local-config.yaml
 
   prometheus:
     image: prom/prometheus
+    restart: unless-stopped
     volumes:
       - prometheus:/prometheus
     ports:
@@ -45,6 +47,8 @@ services:
         /bin/prometheus
 
   grafana:
+    image: grafana/grafana
+    restart: unless-stopped
     environment:
       - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
       - GF_AUTH_ANONYMOUS_ENABLED=true
@@ -77,7 +81,6 @@ services:
           editable: false
         EOF
         /run.sh
-    image: grafana/grafana
     ports:
       - 3000:3000
     links:


### PR DESCRIPTION
- `Grafana` `Loki` `Promethesu` 3종 세트를 추가하며 각 컨테이너에 대해 `restart` 옵션을 주지 않아 `EC2` 를 재부팅 하면 모니터링 컨테이너는 재실행 되지 않던 것을 `restart` 옵션을 추가함으로써 작동하도록 변경하였습니다.

- 또한 `Grafana` 컨테이너가 재부팅 되면 데이터가 사라져 `Contact Points` 에 `Discord Webhook` 설정 등이 사라지는 점을 `volume` 을 추가함으로써 해결하였습니다.