### PR TITLE
✨ blocked user fillter

### DIFF
--- a/backend/src/main/java/net/pengcook/authentication/config/LoginUserArgumentResolverConfig.java
+++ b/backend/src/main/java/net/pengcook/authentication/config/LoginUserArgumentResolverConfig.java
@@ -2,16 +2,24 @@ package net.pengcook.authentication.config;
 
 import java.util.List;
 import lombok.AllArgsConstructor;
+import net.pengcook.authentication.interceptor.UserInfoInterceptor;
 import net.pengcook.authentication.resolver.LoginUserArgumentResolver;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 @AllArgsConstructor
 public class LoginUserArgumentResolverConfig implements WebMvcConfigurer {
 
+    private final UserInfoInterceptor userInfoInterceptor;
     private final LoginUserArgumentResolver loginUserArgumentResolver;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(userInfoInterceptor);
+    }
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {

--- a/backend/src/main/java/net/pengcook/authentication/config/LoginUserArgumentResolverConfig.java
+++ b/backend/src/main/java/net/pengcook/authentication/config/LoginUserArgumentResolverConfig.java
@@ -1,7 +1,7 @@
 package net.pengcook.authentication.config;
 
 import java.util.List;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import net.pengcook.authentication.interceptor.UserInfoInterceptor;
 import net.pengcook.authentication.resolver.LoginUserArgumentResolver;
 import org.springframework.context.annotation.Configuration;
@@ -10,7 +10,7 @@ import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class LoginUserArgumentResolverConfig implements WebMvcConfigurer {
 
     private final UserInfoInterceptor userInfoInterceptor;

--- a/backend/src/main/java/net/pengcook/authentication/controller/LoginController.java
+++ b/backend/src/main/java/net/pengcook/authentication/controller/LoginController.java
@@ -1,7 +1,7 @@
 package net.pengcook.authentication.controller;
 
 import jakarta.validation.Valid;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import net.pengcook.authentication.dto.GoogleLoginRequest;
 import net.pengcook.authentication.dto.GoogleLoginResponse;
 import net.pengcook.authentication.dto.GoogleSignUpRequest;
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class LoginController {
 
     private final LoginService LoginService;

--- a/backend/src/main/java/net/pengcook/authentication/interceptor/UserInfoInterceptor.java
+++ b/backend/src/main/java/net/pengcook/authentication/interceptor/UserInfoInterceptor.java
@@ -1,0 +1,45 @@
+package net.pengcook.authentication.interceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.AllArgsConstructor;
+import net.pengcook.authentication.domain.JwtTokenManager;
+import net.pengcook.authentication.domain.TokenExtractor;
+import net.pengcook.authentication.domain.TokenPayload;
+import net.pengcook.authentication.domain.UserInfo;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+@AllArgsConstructor
+public class UserInfoInterceptor implements HandlerInterceptor {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+
+    private final JwtTokenManager jwtTokenManager;
+    private final TokenExtractor tokenExtractor;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        try {
+            String authorizationHeader = request.getHeader(AUTHORIZATION_HEADER);
+            String accessToken = tokenExtractor.extractToken(authorizationHeader);
+
+            TokenPayload tokenPayload = jwtTokenManager.extract(accessToken);
+            tokenPayload.validateAccessToken("헤더에 토큰이 access token이 아닙니다.");
+            UserInfo userInfo = new UserInfo(tokenPayload.userId(), tokenPayload.email());
+
+            setUserInfoAttribute(userInfo);
+        } catch (Exception e) {
+            setUserInfoAttribute(null);
+        }
+        return true;
+    }
+
+    private void setUserInfoAttribute(UserInfo userInfo) {
+        RequestAttributes requestAttributes = RequestContextHolder.currentRequestAttributes();
+        requestAttributes.setAttribute(UserInfo.class.getName(), userInfo, RequestAttributes.SCOPE_REQUEST);
+    }
+}

--- a/backend/src/main/java/net/pengcook/authentication/interceptor/UserInfoInterceptor.java
+++ b/backend/src/main/java/net/pengcook/authentication/interceptor/UserInfoInterceptor.java
@@ -2,7 +2,7 @@ package net.pengcook.authentication.interceptor;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import net.pengcook.authentication.domain.JwtTokenManager;
 import net.pengcook.authentication.domain.TokenExtractor;
 import net.pengcook.authentication.domain.TokenPayload;
@@ -13,7 +13,7 @@ import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 @Component
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class UserInfoInterceptor implements HandlerInterceptor {
 
     private static final String AUTHORIZATION_HEADER = "Authorization";

--- a/backend/src/main/java/net/pengcook/authentication/resolver/LoginUserArgumentResolver.java
+++ b/backend/src/main/java/net/pengcook/authentication/resolver/LoginUserArgumentResolver.java
@@ -9,6 +9,8 @@ import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
@@ -39,7 +41,11 @@ public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver 
 
         TokenPayload tokenPayload = jwtTokenManager.extract(accessToken);
         tokenPayload.validateAccessToken("헤더에 토큰이 access token이 아닙니다.");
+        UserInfo userInfo = new UserInfo(tokenPayload.userId(), tokenPayload.email());
 
-        return new UserInfo(tokenPayload.userId(), tokenPayload.email());
+        RequestAttributes requestAttributes = RequestContextHolder.currentRequestAttributes();
+        requestAttributes.setAttribute(UserInfo.class.getName(), userInfo, RequestAttributes.SCOPE_REQUEST);
+
+        return userInfo;
     }
 }

--- a/backend/src/main/java/net/pengcook/authentication/resolver/LoginUserArgumentResolver.java
+++ b/backend/src/main/java/net/pengcook/authentication/resolver/LoginUserArgumentResolver.java
@@ -1,6 +1,6 @@
 package net.pengcook.authentication.resolver;
 
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import net.pengcook.authentication.domain.JwtTokenManager;
 import net.pengcook.authentication.domain.TokenExtractor;
 import net.pengcook.authentication.domain.TokenPayload;
@@ -13,7 +13,7 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 @Component
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver {
 
     private static final String AUTHORIZATION_HEADER = "Authorization";

--- a/backend/src/main/java/net/pengcook/authentication/resolver/LoginUserArgumentResolver.java
+++ b/backend/src/main/java/net/pengcook/authentication/resolver/LoginUserArgumentResolver.java
@@ -9,8 +9,6 @@ import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
-import org.springframework.web.context.request.RequestAttributes;
-import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
@@ -42,9 +40,6 @@ public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver 
         TokenPayload tokenPayload = jwtTokenManager.extract(accessToken);
         tokenPayload.validateAccessToken("헤더에 토큰이 access token이 아닙니다.");
         UserInfo userInfo = new UserInfo(tokenPayload.userId(), tokenPayload.email());
-
-        RequestAttributes requestAttributes = RequestContextHolder.currentRequestAttributes();
-        requestAttributes.setAttribute(UserInfo.class.getName(), userInfo, RequestAttributes.SCOPE_REQUEST);
 
         return userInfo;
     }

--- a/backend/src/main/java/net/pengcook/authentication/resolver/LoginUserArgumentResolver.java
+++ b/backend/src/main/java/net/pengcook/authentication/resolver/LoginUserArgumentResolver.java
@@ -39,8 +39,7 @@ public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver 
 
         TokenPayload tokenPayload = jwtTokenManager.extract(accessToken);
         tokenPayload.validateAccessToken("헤더에 토큰이 access token이 아닙니다.");
-        UserInfo userInfo = new UserInfo(tokenPayload.userId(), tokenPayload.email());
 
-        return userInfo;
+        return new UserInfo(tokenPayload.userId(), tokenPayload.email());
     }
 }

--- a/backend/src/main/java/net/pengcook/authentication/service/LoginService.java
+++ b/backend/src/main/java/net/pengcook/authentication/service/LoginService.java
@@ -3,7 +3,7 @@ package net.pengcook.authentication.service;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseAuthException;
 import com.google.firebase.auth.FirebaseToken;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import net.pengcook.authentication.domain.JwtTokenManager;
 import net.pengcook.authentication.domain.TokenPayload;
 import net.pengcook.authentication.domain.TokenType;
@@ -19,7 +19,7 @@ import net.pengcook.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
 
 @Service
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class LoginService {
 
     private final FirebaseAuth firebaseAuth;

--- a/backend/src/main/java/net/pengcook/recipe/dto/RecipeDataResponse.java
+++ b/backend/src/main/java/net/pengcook/recipe/dto/RecipeDataResponse.java
@@ -2,6 +2,7 @@ package net.pengcook.recipe.dto;
 
 import java.time.LocalTime;
 import net.pengcook.ingredient.domain.Requirement;
+import net.pengcook.user.domain.AuthorAble;
 
 public record RecipeDataResponse(
         long recipeId,
@@ -19,5 +20,10 @@ public record RecipeDataResponse(
         long ingredientId,
         String ingredientName,
         Requirement ingredientRequirement
-) {
+) implements AuthorAble {
+
+    @Override
+    public long getAuthorId() {
+        return authorId;
+    }
 }

--- a/backend/src/main/java/net/pengcook/user/aop/BlockedUserFilterAspect.java
+++ b/backend/src/main/java/net/pengcook/user/aop/BlockedUserFilterAspect.java
@@ -1,0 +1,90 @@
+package net.pengcook.user.aop;
+
+import java.util.List;
+import java.util.Optional;
+import lombok.AllArgsConstructor;
+import net.pengcook.authentication.domain.UserInfo;
+import net.pengcook.user.domain.AuthorAble;
+import net.pengcook.user.domain.BlockedUserGroup;
+import net.pengcook.user.service.UserService;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+
+@Aspect
+@Component
+@AllArgsConstructor
+public class BlockedUserFilterAspect {
+
+    private final UserService userService;
+
+    @Pointcut("execution(java.util.List<net.pengcook.user.domain.AuthorAble+> net.pengcook..repository..*(..))")
+    public void repositoryMethodsReturningListOfAuthorAble() {
+    }
+
+    @Around("repositoryMethodsReturningListOfAuthorAble()")
+    public Object filterAuthorAbles(ProceedingJoinPoint joinPoint) throws Throwable {
+        List<AuthorAble> authorAbles = (List<AuthorAble>) joinPoint.proceed();
+        RequestAttributes requestAttributes = RequestContextHolder.currentRequestAttributes();
+        UserInfo userInfo = (UserInfo) requestAttributes.getAttribute(UserInfo.class.getName(), RequestAttributes.SCOPE_REQUEST);
+
+        if (userInfo == null) {
+            return authorAbles;
+        }
+
+        BlockedUserGroup blockedUserGroup = userService.getBlockedUserGroup(userInfo.getId());
+
+        return authorAbles.stream()
+                .filter(item -> !blockedUserGroup.isBlocked(item.getAuthorId()))
+                .toList();
+    }
+
+    @Pointcut("execution(java.util.Optional<net.pengcook.user.domain.AuthorAble+> net.pengcook..repository..*(..))")
+    public void repositoryFindMethodsReturningSingleAuthorAble() {
+    }
+
+    @Around("repositoryFindMethodsReturningSingleAuthorAble()")
+    public Object filterAuthorAbleFind(ProceedingJoinPoint joinPoint) throws Throwable {
+        Optional<AuthorAble> authorAbleOptional = (Optional<AuthorAble>) joinPoint.proceed();
+        RequestAttributes requestAttributes = RequestContextHolder.currentRequestAttributes();
+        UserInfo userInfo = (UserInfo) requestAttributes.getAttribute(UserInfo.class.getName(), RequestAttributes.SCOPE_REQUEST);
+
+        if (userInfo == null) {
+            return authorAbleOptional;
+        }
+        BlockedUserGroup blockedUserGroup = userService.getBlockedUserGroup(userInfo.getId());
+
+        if (authorAbleOptional.isPresent()) {
+            AuthorAble authorAble = authorAbleOptional.get();
+            if (!blockedUserGroup.isBlocked(authorAble.getAuthorId())) {
+                return authorAbleOptional;
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Pointcut("execution(net.pengcook.user.domain.AuthorAble+ net.pengcook..repository..*(..))")
+    public void repositoryGetMethodsReturningSingleAuthorAble() {
+    }
+
+    @Around("repositoryGetMethodsReturningSingleAuthorAble()")
+    public Object filterAuthorAbleGet(ProceedingJoinPoint joinPoint) throws Throwable {
+        AuthorAble authorAble = (AuthorAble) joinPoint.proceed();
+        RequestAttributes requestAttributes = RequestContextHolder.currentRequestAttributes();
+        UserInfo userInfo = (UserInfo) requestAttributes.getAttribute(UserInfo.class.getName(), RequestAttributes.SCOPE_REQUEST);
+
+        if (userInfo == null) {
+            return authorAble;
+        }
+        BlockedUserGroup blockedUserGroup = userService.getBlockedUserGroup(userInfo.getId());
+
+        if (blockedUserGroup.isBlocked(authorAble.getAuthorId())) {
+            return null;
+        }
+        return authorAble;
+    }
+}

--- a/backend/src/main/java/net/pengcook/user/aop/BlockedUserFilterAspect.java
+++ b/backend/src/main/java/net/pengcook/user/aop/BlockedUserFilterAspect.java
@@ -2,7 +2,7 @@ package net.pengcook.user.aop;
 
 import java.util.List;
 import java.util.Optional;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import net.pengcook.authentication.domain.UserInfo;
 import net.pengcook.user.domain.AuthorAble;
 import net.pengcook.user.domain.BlockedUserGroup;
@@ -17,7 +17,7 @@ import org.springframework.web.context.request.RequestContextHolder;
 
 @Aspect
 @Component
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class BlockedUserFilterAspect {
 
     private final UserService userService;

--- a/backend/src/main/java/net/pengcook/user/controller/UserController.java
+++ b/backend/src/main/java/net/pengcook/user/controller/UserController.java
@@ -1,11 +1,14 @@
 package net.pengcook.user.controller;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import net.pengcook.authentication.domain.UserInfo;
 import net.pengcook.authentication.resolver.LoginUser;
 import net.pengcook.user.dto.UserReportRequest;
 import net.pengcook.user.dto.UserReportResponse;
+import net.pengcook.user.dto.UserBlockRequest;
+import net.pengcook.user.dto.UserBlockResponse;
 import net.pengcook.user.dto.UserResponse;
 import net.pengcook.user.dto.UsernameCheckResponse;
 import net.pengcook.user.service.UserService;
@@ -37,5 +40,11 @@ public class UserController {
     @ResponseStatus(HttpStatus.CREATED)
     public UserReportResponse report(@LoginUser UserInfo userInfo, @RequestBody UserReportRequest userReportRequest) {
         return userService.reportUser(userInfo.getId(), userReportRequest);
+    }
+
+    @PostMapping("/api/user/block")
+    @ResponseStatus(HttpStatus.CREATED)
+    public UserBlockResponse blockUser(@LoginUser UserInfo userInfo, @RequestBody @Valid UserBlockRequest userBlockRequest) {
+        return userService.blockUser(userInfo.getId(), userBlockRequest.blockeeId());
     }
 }

--- a/backend/src/main/java/net/pengcook/user/domain/AuthorAble.java
+++ b/backend/src/main/java/net/pengcook/user/domain/AuthorAble.java
@@ -1,0 +1,6 @@
+package net.pengcook.user.domain;
+
+public interface AuthorAble {
+
+    long getAuthorId();
+}

--- a/backend/src/main/java/net/pengcook/user/domain/BlockedUserGroup.java
+++ b/backend/src/main/java/net/pengcook/user/domain/BlockedUserGroup.java
@@ -10,7 +10,6 @@ public class BlockedUserGroup {
 
     public boolean isBlocked(long userId) {
         return users.stream()
-                .map(User::getId)
-                .anyMatch(id -> id == userId);
+                .anyMatch(user -> user.isSameUser(userId));
     }
 }

--- a/backend/src/main/java/net/pengcook/user/domain/BlockedUserGroup.java
+++ b/backend/src/main/java/net/pengcook/user/domain/BlockedUserGroup.java
@@ -1,0 +1,16 @@
+package net.pengcook.user.domain;
+
+import java.util.Set;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class BlockedUserGroup {
+
+    private final Set<User> users;
+
+    public boolean isBlocked(long userId) {
+        return users.stream()
+                .map(User::getId)
+                .anyMatch(id -> id == userId);
+    }
+}

--- a/backend/src/main/java/net/pengcook/user/domain/User.java
+++ b/backend/src/main/java/net/pengcook/user/domain/User.java
@@ -42,4 +42,8 @@ public class User {
     public User(String email, String username, String nickname, String image, String region) {
         this(0L, email, username, nickname, image, region);
     }
+
+    public boolean isSameUser(long userId) {
+        return this.id == userId;
+    }
 }

--- a/backend/src/main/java/net/pengcook/user/domain/User.java
+++ b/backend/src/main/java/net/pengcook/user/domain/User.java
@@ -8,13 +8,15 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "users")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+@EqualsAndHashCode(of = "id")
 @Getter
 public class User {
 

--- a/backend/src/main/java/net/pengcook/user/domain/UserBlock.java
+++ b/backend/src/main/java/net/pengcook/user/domain/UserBlock.java
@@ -1,0 +1,53 @@
+package net.pengcook.user.domain;
+
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import net.pengcook.user.exception.BadArgumentException;
+
+@Entity
+@Table
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode(of = "id")
+@Getter
+public class UserBlock {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @ManyToOne
+    @JoinColumn(name = "blocker_id")
+    private User blocker;
+
+    @ManyToOne
+    @JoinColumn(name = "blockee_id")
+    private User blockee;
+
+    public UserBlock(User blocker, User blockee) {
+        this(0L, blocker, blockee);
+    }
+
+    public UserBlock(long id, User blocker, User blockee) {
+        validate(blocker, blockee);
+
+        this.id = id;
+        this.blocker = blocker;
+        this.blockee = blockee;
+    }
+
+    private void validate(User blocker, User blockee) {
+        if (blocker.equals(blockee)) {
+            throw new BadArgumentException("자기 자신을 차단할 수 없습니다.");
+        }
+    }
+}

--- a/backend/src/main/java/net/pengcook/user/dto/UserBlockRequest.java
+++ b/backend/src/main/java/net/pengcook/user/dto/UserBlockRequest.java
@@ -1,0 +1,6 @@
+package net.pengcook.user.dto;
+
+import com.google.firebase.database.annotations.NotNull;
+
+public record UserBlockRequest(@NotNull long blockeeId) {
+}

--- a/backend/src/main/java/net/pengcook/user/dto/UserBlockResponse.java
+++ b/backend/src/main/java/net/pengcook/user/dto/UserBlockResponse.java
@@ -1,0 +1,7 @@
+package net.pengcook.user.dto;
+
+public record UserBlockResponse(
+        UserResponse blocker,
+        UserResponse blockee
+) {
+}

--- a/backend/src/main/java/net/pengcook/user/dto/UserBlockResponse.java
+++ b/backend/src/main/java/net/pengcook/user/dto/UserBlockResponse.java
@@ -1,7 +1,4 @@
 package net.pengcook.user.dto;
 
-public record UserBlockResponse(
-        UserResponse blocker,
-        UserResponse blockee
-) {
+public record UserBlockResponse(UserResponse blocker, UserResponse blockee) {
 }

--- a/backend/src/main/java/net/pengcook/user/exception/BadArgumentException.java
+++ b/backend/src/main/java/net/pengcook/user/exception/BadArgumentException.java
@@ -1,0 +1,10 @@
+package net.pengcook.user.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class BadArgumentException extends UserException {
+
+    public BadArgumentException(String message) {
+        super(HttpStatus.BAD_REQUEST, message);
+    }
+}

--- a/backend/src/main/java/net/pengcook/user/exception/UserNotFoundException.java
+++ b/backend/src/main/java/net/pengcook/user/exception/UserNotFoundException.java
@@ -1,0 +1,10 @@
+package net.pengcook.user.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class UserNotFoundException extends UserException {
+
+    public UserNotFoundException(String message) {
+        super(HttpStatus.NOT_FOUND, message);
+    }
+}

--- a/backend/src/main/java/net/pengcook/user/repository/UserBlockRepository.java
+++ b/backend/src/main/java/net/pengcook/user/repository/UserBlockRepository.java
@@ -1,9 +1,11 @@
 package net.pengcook.user.repository;
 
+import java.util.List;
 import net.pengcook.user.domain.UserBlock;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserBlockRepository extends JpaRepository<UserBlock, Long> {
+    List<UserBlock> findAllByBlockerId(long id);
 }

--- a/backend/src/main/java/net/pengcook/user/repository/UserBlockRepository.java
+++ b/backend/src/main/java/net/pengcook/user/repository/UserBlockRepository.java
@@ -1,0 +1,9 @@
+package net.pengcook.user.repository;
+
+import net.pengcook.user.domain.UserBlock;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserBlockRepository extends JpaRepository<UserBlock, Long> {
+}

--- a/backend/src/main/java/net/pengcook/user/service/UserService.java
+++ b/backend/src/main/java/net/pengcook/user/service/UserService.java
@@ -5,10 +5,14 @@ import net.pengcook.user.domain.User;
 import net.pengcook.user.domain.UserReport;
 import net.pengcook.user.dto.UserReportRequest;
 import net.pengcook.user.dto.UserReportResponse;
+import net.pengcook.user.domain.UserBlock;
+import net.pengcook.user.dto.UserBlockResponse;
 import net.pengcook.user.dto.UserResponse;
 import net.pengcook.user.dto.UsernameCheckResponse;
 import net.pengcook.user.exception.NotFoundException;
 import net.pengcook.user.repository.UserReportRepository;
+import net.pengcook.user.exception.UserNotFoundException;
+import net.pengcook.user.repository.UserBlockRepository;
 import net.pengcook.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
 
@@ -17,16 +21,26 @@ import org.springframework.stereotype.Service;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final UserBlockRepository userBlockRepository;
     private final UserReportRepository userReportRepository;
 
     public UserResponse getUserById(long id) {
-        User user = userRepository.findById(id).orElseThrow();
+        User user = userRepository.findById(id).orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
         return new UserResponse(user);
     }
 
     public UsernameCheckResponse checkUsername(String username) {
         boolean userExists = userRepository.existsByUsername(username);
         return new UsernameCheckResponse(!userExists);
+    }
+
+    public UserBlockResponse blockUser(long blockerId, long blockeeId) {
+        User blocker = userRepository.findById(blockerId).orElseThrow(() -> new UserNotFoundException("차단하는 사용자를 찾을 수 없습니다."));
+        User blockee = userRepository.findById(blockeeId).orElseThrow(() -> new UserNotFoundException("차단할 사용자를 찾을 수 없습니다."));
+
+        UserBlock userBlock = userBlockRepository.save(new UserBlock(blocker, blockee));
+
+        return new UserBlockResponse(new UserResponse(userBlock.getBlocker()), new UserResponse(userBlock.getBlockee()));
     }
 
     public UserReportResponse reportUser(long reporterId, UserReportRequest userReportRequest) {

--- a/backend/src/main/java/net/pengcook/user/service/UserService.java
+++ b/backend/src/main/java/net/pengcook/user/service/UserService.java
@@ -37,7 +37,7 @@ public class UserService {
     }
 
     public UserBlockResponse blockUser(long blockerId, long blockeeId) {
-        User blocker = userRepository.findById(blockerId).orElseThrow(() -> new UserNotFoundException("차단하는 사용자를 찾을 수 없습니다."));
+        User blocker = userRepository.findById(blockerId).orElseThrow(() -> new UserNotFoundException("정상적으로 로그인되지 않았습니다."));
         User blockee = userRepository.findById(blockeeId).orElseThrow(() -> new UserNotFoundException("차단할 사용자를 찾을 수 없습니다."));
 
         UserBlock userBlock = userBlockRepository.save(new UserBlock(blocker, blockee));

--- a/backend/src/main/java/net/pengcook/user/service/UserService.java
+++ b/backend/src/main/java/net/pengcook/user/service/UserService.java
@@ -1,6 +1,8 @@
 package net.pengcook.user.service;
 
+import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
+import net.pengcook.user.domain.BlockedUserGroup;
 import net.pengcook.user.domain.User;
 import net.pengcook.user.domain.UserReport;
 import net.pengcook.user.dto.UserReportRequest;
@@ -57,5 +59,12 @@ public class UserService {
 
         UserReport savedUserReport = userReportRepository.save(userReport);
         return new UserReportResponse(savedUserReport);
+    }
+
+    public BlockedUserGroup getBlockedUserGroup(long blockerId) {
+
+        return userBlockRepository.findAllByBlockerId(blockerId).stream()
+                .map(UserBlock::getBlockee)
+                .collect(Collectors.collectingAndThen(Collectors.toSet(), BlockedUserGroup::new));
     }
 }

--- a/backend/src/test/java/net/pengcook/authentication/controller/LoginControllerTest.java
+++ b/backend/src/test/java/net/pengcook/authentication/controller/LoginControllerTest.java
@@ -118,7 +118,7 @@ class LoginControllerTest extends RestDocsSetting {
     }
 
     @Test
-    @DisplayName("구글 계정으로 회원가입을 할 수 있다.")
+    @DisplayName("구글 계정으로 회원가입을 한다.")
     void signUpWithGoogle() throws FirebaseAuthException {
         String email = "new_face@pengcook.net";
         String idToken = "test.id.token";

--- a/backend/src/test/java/net/pengcook/authentication/service/LoginServiceTest.java
+++ b/backend/src/test/java/net/pengcook/authentication/service/LoginServiceTest.java
@@ -82,7 +82,7 @@ class LoginServiceTest {
     }
 
     @Test
-    @DisplayName("구글 계정으로 회원가입을 할 수 있다.")
+    @DisplayName("구글 계정으로 회원가입을 한다.")
     void signUpWithGoogle() throws FirebaseAuthException {
         String email = "new_face@pengcook.net";
         String idToken = "test.id.token";

--- a/backend/src/test/java/net/pengcook/category/service/CategoryServiceTest.java
+++ b/backend/src/test/java/net/pengcook/category/service/CategoryServiceTest.java
@@ -8,7 +8,6 @@ import java.util.List;
 import net.pengcook.category.repository.CategoryRecipeRepository;
 import net.pengcook.category.repository.CategoryRepository;
 import net.pengcook.recipe.domain.Recipe;
-import net.pengcook.recipe.service.RecipeService;
 import net.pengcook.user.domain.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -33,7 +32,7 @@ class CategoryServiceTest {
     private CategoryRecipeRepository categoryRecipeRepository;
 
     @Test
-    @DisplayName("레시피의 카테고리를 저장할 수 있다.")
+    @DisplayName("레시피의 카테고리를 저장한다.")
     void saveCategories() {
         User author = new User("ela@pengcook.net", "ela", "엘라", "ela.jpg", "KOREA");
         Recipe recipe = new Recipe(1L, "김치볶음밥", author, LocalTime.of(0, 30, 0), "김치볶음밥이미지.jpg", 3, 2, "김치볶음밥 조리법");

--- a/backend/src/test/java/net/pengcook/user/aop/BlockedUserFilterAspectTest.java
+++ b/backend/src/test/java/net/pengcook/user/aop/BlockedUserFilterAspectTest.java
@@ -1,0 +1,45 @@
+package net.pengcook.user.aop;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.restassured.RestAssured;
+import java.util.List;
+import net.pengcook.authentication.annotation.WithLoginUser;
+import net.pengcook.authentication.annotation.WithLoginUserTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.jdbc.Sql;
+
+
+@WithLoginUserTest
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Sql(value = "/data/blocked-user.sql")
+class BlockedUserFilterAspectTest {
+
+    @LocalServerPort
+    int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Test
+    @WithLoginUser(email = "loki@pengcook.net")
+    @DisplayName("레시피 목록을 조회할때 차단한 사용자들의 레시피가 보이지 않는다.")
+    void filterAuthorAbles() {
+        List<Long> authorIds = RestAssured.given().log().all()
+                .queryParam("pageNumber", 0)
+                .queryParam("pageSize", 10)
+                .when()
+                .get("/api/recipes")
+                .then().log().all()
+                .extract().jsonPath()
+                .getList("author.authorId", Long.class);
+
+        assertThat(authorIds).doesNotContain(2L, 4L, 6L, 8L);
+    }
+}

--- a/backend/src/test/java/net/pengcook/user/controller/UserControllerTest.java
+++ b/backend/src/test/java/net/pengcook/user/controller/UserControllerTest.java
@@ -14,6 +14,7 @@ import io.restassured.http.ContentType;
 import net.pengcook.RestDocsSetting;
 import net.pengcook.authentication.annotation.WithLoginUser;
 import net.pengcook.authentication.annotation.WithLoginUserTest;
+import net.pengcook.user.dto.UserBlockRequest;
 import net.pengcook.user.dto.UserReportRequest;
 import net.pengcook.user.dto.UserResponse;
 import org.junit.jupiter.api.DisplayName;
@@ -142,5 +143,42 @@ class UserControllerTest extends RestDocsSetting {
                 .body("reporteeId", is(1))
                 .body("reason", is("SPAM"))
                 .body("details", is("스팸 컨텐츠입니다."));
+    }
+
+    @Test
+    @WithLoginUser(email = "loki@pengcook.net")
+    @DisplayName("사용자를 차단한다.")
+    void blockUser() {
+        UserBlockRequest userBlockRequest = new UserBlockRequest(2L);
+
+        RestAssured.given(spec).log().all()
+                .filter(document(DEFAULT_RESTDOCS_PATH,
+                        "사용자를 차단합니다.",
+                        "사용자 차단 API",
+                        requestFields(
+                                fieldWithPath("blockeeId").description("차단할 사용자 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("blocker.id").description("차단자 ID"),
+                                fieldWithPath("blocker.email").description("차단자 이메일"),
+                                fieldWithPath("blocker.username").description("차단자 아이디"),
+                                fieldWithPath("blocker.nickname").description("차단자 닉네임"),
+                                fieldWithPath("blocker.image").description("차단자 프로필 이미지"),
+                                fieldWithPath("blocker.region").description("차단자 국가"),
+                                fieldWithPath("blockee.id").description("차단대상 ID"),
+                                fieldWithPath("blockee.email").description("차단대상 이메일"),
+                                fieldWithPath("blockee.username").description("차단대상 아이디"),
+                                fieldWithPath("blockee.nickname").description("차단대상 닉네임"),
+                                fieldWithPath("blockee.image").description("차단대상 프로필 이미지"),
+                                fieldWithPath("blockee.region").description("차단대상 국가")
+                        )
+                ))
+                .contentType(ContentType.JSON)
+                .body(userBlockRequest)
+                .when().post("/api/user/block")
+                .then().log().all()
+                .statusCode(201)
+                .body("blocker.id", is(1))
+                .body("blockee.id", is(2));
     }
 }

--- a/backend/src/test/java/net/pengcook/user/domain/BlockedUserGroupTest.java
+++ b/backend/src/test/java/net/pengcook/user/domain/BlockedUserGroupTest.java
@@ -1,0 +1,23 @@
+package net.pengcook.user.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class BlockedUserGroupTest {
+
+    @Test
+    void isBlocked() {
+        User loki = new User(1L, "loki@pengcook.net", "loki", "로키", "loki.jpg", "KOREA");
+        User pond = new User(2L, "pond@pengcook.net", "pond", "폰드", "pond.jpg", "KOREA");
+
+        BlockedUserGroup blockedUserGroup = new BlockedUserGroup(Set.of(pond));
+
+        assertAll(
+                () -> assertThat(blockedUserGroup.isBlocked(loki.getId())).isFalse(),
+                () -> assertThat(blockedUserGroup.isBlocked(pond.getId())).isTrue()
+        );
+    }
+}

--- a/backend/src/test/java/net/pengcook/user/domain/UserBlockTest.java
+++ b/backend/src/test/java/net/pengcook/user/domain/UserBlockTest.java
@@ -1,0 +1,36 @@
+package net.pengcook.user.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import net.pengcook.user.exception.BadArgumentException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class UserBlockTest {
+
+    @Test
+    @DisplayName("UserBlock 객체를 생성할 수 있다.")
+    void create() {
+        User user_loki = new User(1L, "loki@pengcook.net", "loki", "로키", "loki.jpg", "KOREA");
+        User user_pond = new User(2L, "pond@pengcook.net", "pond", "폰드", "pond.jpg", "KOREA");
+
+        UserBlock userBlock = new UserBlock(user_loki, user_pond);
+
+        assertAll(
+                () -> assertThat(userBlock.getBlocker()).isEqualTo(user_loki),
+                () -> assertThat(userBlock.getBlockee()).isEqualTo(user_pond)
+        );
+    }
+
+    @Test
+    @DisplayName("차단자와 차단대상이 같으면 예외가 발생한다.")
+    void createWhenBlockerIsBlockee() {
+        User user_loki = new User("loki@pengcook.net", "loki", "로키", "loki.jpg", "KOREA");
+
+        assertThatThrownBy(() -> new UserBlock(user_loki, user_loki))
+                .isInstanceOf(BadArgumentException.class)
+                .hasMessage("자기 자신을 차단할 수 없습니다.");
+    }
+}

--- a/backend/src/test/java/net/pengcook/user/domain/UserBlockTest.java
+++ b/backend/src/test/java/net/pengcook/user/domain/UserBlockTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 class UserBlockTest {
 
     @Test
-    @DisplayName("UserBlock 객체를 생성할 수 있다.")
+    @DisplayName("UserBlock 객체를 생성한다.")
     void create() {
         User user_loki = new User(1L, "loki@pengcook.net", "loki", "로키", "loki.jpg", "KOREA");
         User user_pond = new User(2L, "pond@pengcook.net", "pond", "폰드", "pond.jpg", "KOREA");

--- a/backend/src/test/java/net/pengcook/user/service/UserServiceTest.java
+++ b/backend/src/test/java/net/pengcook/user/service/UserServiceTest.java
@@ -125,7 +125,7 @@ class UserServiceTest {
 
         assertThatThrownBy(() -> userService.blockUser(blockerId, blockeeId))
                 .isInstanceOf(UserNotFoundException.class)
-                .hasMessage("차단하는 사용자를 찾을 수 없습니다.");
+                .hasMessage("정상적으로 로그인되지 않았습니다.");
     }
 
     @Test

--- a/backend/src/test/java/net/pengcook/user/service/UserServiceTest.java
+++ b/backend/src/test/java/net/pengcook/user/service/UserServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import net.pengcook.user.domain.BlockedUserGroup;
 import java.util.NoSuchElementException;
 import net.pengcook.user.domain.UserReport;
 import net.pengcook.user.dto.UserReportRequest;
@@ -136,5 +137,19 @@ class UserServiceTest {
         assertThatThrownBy(() -> userService.blockUser(blockerId, blockeeId))
                 .isInstanceOf(UserNotFoundException.class)
                 .hasMessage("차단할 사용자를 찾을 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("차단한 사용자들의 목록을 불러올 수 있다.")
+    void getBlockedUserGroup() {
+        long blockerId = 1L;
+
+        BlockedUserGroup blockedUserGroup = userService.getBlockedUserGroup(blockerId);
+
+        assertAll(
+                () -> assertThat(blockedUserGroup.isBlocked(2L)).isTrue(),
+                () -> assertThat(blockedUserGroup.isBlocked(3L)).isTrue(),
+                () -> assertThat(blockedUserGroup.isBlocked(4L)).isFalse()
+        );
     }
 }

--- a/backend/src/test/java/net/pengcook/user/service/UserServiceTest.java
+++ b/backend/src/test/java/net/pengcook/user/service/UserServiceTest.java
@@ -103,7 +103,7 @@ class UserServiceTest {
     }
 
     @Test
-    @DisplayName("사용자를 차단할 수 있다.")
+    @DisplayName("사용자를 차단한다.")
     void blockUser() {
         long blockerId = 1L;
         long blockeeId = 2L;

--- a/backend/src/test/resources/data/blocked-user.sql
+++ b/backend/src/test/resources/data/blocked-user.sql
@@ -1,0 +1,159 @@
+SET REFERENTIAL_INTEGRITY FALSE;
+
+TRUNCATE TABLE users;
+ALTER TABLE users ALTER COLUMN id RESTART;
+
+TRUNCATE TABLE user_block;
+ALTER TABLE user_block ALTER COLUMN id RESTART;
+
+TRUNCATE TABLE category;
+ALTER TABLE category ALTER COLUMN id RESTART;
+
+TRUNCATE TABLE ingredient;
+ALTER TABLE ingredient ALTER COLUMN id RESTART;
+
+TRUNCATE TABLE recipe;
+ALTER TABLE recipe ALTER COLUMN id RESTART;
+
+TRUNCATE TABLE category_recipe;
+ALTER TABLE category_recipe ALTER COLUMN id RESTART;
+
+TRUNCATE TABLE ingredient_recipe;
+ALTER TABLE ingredient_recipe ALTER COLUMN id RESTART;
+
+TRUNCATE TABLE recipe_step;
+ALTER TABLE recipe_step ALTER COLUMN id RESTART;
+
+SET REFERENTIAL_INTEGRITY TRUE;
+
+INSERT INTO users (email, username, nickname, image, region)
+VALUES ('loki@pengcook.net', 'loki', '로키', 'loki.jpg', 'KOREA'),
+       ('ela@pengcook.net', 'ela', '엘라', 'ela.jpg', 'KOREA'),
+       ('crocodile@pengcook.net', 'crocodile', '악어', 'crocodile.jpg', 'KOREA'),
+       ('birdsheep@pengcook.net', 'birdsheep', '새양', 'birdsheep.jpg', 'KOREA'),
+       ('pond@pengcook.net', 'pond', '폰드', 'pond.jpg', 'KOREA'),
+       ('ato@pengcook.net', 'ato', '아토', 'ato.jpg', 'KOREA'),
+       ('km@pengcook.net', 'km', '케이엠', 'km.jpg', 'KOREA'),
+       ('hadi@pengcook.net', 'hadi', '하디', 'hadi.jpg', 'KOREA');
+
+INSERT INTO user_block (blocker_id, blockee_id)
+values (1, 2),
+       (1, 4),
+       (1, 6),
+       (1, 8);
+
+INSERT INTO category (name)
+VALUES ('한식'),
+       ('양식'),
+       ('채식'),
+       ('건강식'),
+       ('간편식'),
+       ('디저트'),
+       ('해산물'),
+       ('면요리'),
+       ('샐러드'),
+       ('스프');
+
+INSERT INTO recipe (title, author_id, cooking_time, thumbnail, difficulty, like_count, description)
+VALUES ('김치볶음밥', 1, '00:30:00', '김치볶음밥이미지.jpg', 3, 2, '김치볶음밥 조리법'),
+       ('김밥', 2, '01:00:00', '김밥이미지.jpg', 8, 1, '김밥 조리법'),
+       ('김치찌개', 3, '00:30:00', '김치찌개이미지.jpg', 3, 2, '김치찌개 조리법'),
+       ('토마토스파게티', 4, '00:30:00', '토마토스파게티이미지.jpg', 3, 2, '토마토스파게티 조리법'),
+       ('간장계란밥', 5, '00:10:00', '간장계란밥이미지.jpg', 1, 3, '간장계란밥 조리법'),
+       ('피자', 6, '00:30:00', '피자이미지.jpg', 3, 2, '피자 조리법'),
+       ('된장찌개', 7, '00:30:00', '된장찌개이미지.jpg', 3, 2, '된장찌개 조리법'),
+       ('햄버거', 8, '00:30:00', '햄버거이미지.jpg', 3, 2, '햄버거 조리법'),
+       ('흰쌀밥', 1, '00:40:00', '흰쌀밥이미지.jpg', 2, 4, '흰쌀밥 조리법'),
+       ('샐러드', 2, '00:15:00', '샐러드이미지.jpg', 1, 5, '샐러드 조리법'),
+       ('연어스테이크', 3, '00:45:00', '연어스테이크이미지.jpg', 4, 3, '연어스테이크 조리법'),
+       ('초콜릿 케이크', 4, '01:20:00', '초콜릿케이크이미지.jpg', 5, 6, '초콜릿 케이크 조리법'),
+       ('베지터블 스프', 5, '00:50:00', '베지터블스프이미지.jpg', 3, 2, '베지터블 스프 조리법'),
+       ('카레라이스', 6, '00:30:00', '카레라이스이미지.jpg', 3, 2, '카레라이스 조리법'),
+       ('새우볶음밥', 7, '00:25:00', '새우볶음밥이미지.jpg', 2, 3, '새우볶음밥 조리법');
+
+INSERT INTO category_recipe (category_id, recipe_id)
+VALUES (1, 2),  -- 김밥은 한식
+       (3, 2),  -- 김밥은 채식
+       (1, 3),  -- 김치찌개는 한식
+       (5, 3),  -- 김치찌개는 간편식
+       (2, 4),  -- 토마토스파게티는 양식
+       (4, 5),  -- 간장계란밥은 건강식
+       (5, 5),  -- 간장계란밥은 간편식
+       (2, 6),  -- 피자는 양식
+       (5, 6),  -- 피자는 간편식
+       (1, 7),  -- 된장찌개는 한식
+       (5, 7),  -- 된장찌개는 간편식
+       (2, 8),  -- 햄버거는 양식
+       (5, 8),  -- 햄버거는 간편식
+       (1, 9),  -- 흰쌀밥은 한식
+       (9, 10), -- 샐러드는 샐러드
+       (4, 10), -- 샐러드는 건강식
+       (7, 11), -- 연어스테이크는 해산물
+       (2, 11), -- 연어스테이크는 양식
+       (6, 12), -- 초콜릿 케이크는 디저트
+       (10, 13),-- 베지터블 스프는 스프
+       (3, 13), -- 베지터블 스프는 채식
+       (1, 14), -- 카레라이스는 한식
+       (5, 14), -- 카레라이스는 간편식
+       (7, 15), -- 새우볶음밥은 해산물
+       (1, 15); -- 새우볶음밥은 한식
+
+INSERT INTO ingredient (name)
+VALUES ('김'),
+       ('쌀'),
+       ('계란'),
+       ('김치'),
+       ('오이'),
+       ('후추'),
+       ('간장'),
+       ('소금'),
+       ('햄'),
+       ('토마토'),
+       ('밀가루'),
+       ('새우'),
+       ('버터'),
+       ('설탕'),
+       ('초콜릿'),
+       ('버섯'),
+       ('양파'),
+       ('피망');
+
+INSERT INTO ingredient_recipe (ingredient_id, recipe_id, requirement)
+VALUES (1, 1, 'REQUIRED'),  -- 김치볶음밥
+       (2, 1, 'REQUIRED'),  -- 김치볶음밥
+       (3, 1, 'ALTERNATIVE'),  -- 김치볶음밥
+       (4, 1, 'OPTIONAL'),  -- 김치볶음밥
+       (2, 2, 'REQUIRED'),  -- 김밥
+       (3, 2, 'OPTIONAL'),  -- 김밥
+       (4, 2, 'REQUIRED'),  -- 김밥
+       (2, 3, 'REQUIRED'),  -- 김치찌개
+       (3, 3, 'REQUIRED'),  -- 김치찌개
+       (7, 3, 'REQUIRED'),  -- 김치찌개
+       (2, 4, 'REQUIRED'),  -- 토마토스파게티
+       (5, 4, 'OPTIONAL'),  -- 토마토스파게티
+       (10, 4, 'REQUIRED'), -- 토마토스파게티
+       (8, 5, 'REQUIRED'),  -- 간장계란밥
+       (3, 5, 'REQUIRED'),  -- 간장계란밥
+       (9, 6, 'REQUIRED'),  -- 피자
+       (6, 6, 'OPTIONAL'),  -- 피자
+       (4, 7, 'REQUIRED'),  -- 된장찌개
+       (2, 7, 'REQUIRED'),  -- 된장찌개
+       (8, 8, 'OPTIONAL'),  -- 햄버거
+       (9, 8, 'REQUIRED'),  -- 햄버거
+       (2, 9, 'REQUIRED'),  -- 흰쌀밥
+       (1, 9, 'OPTIONAL'),  -- 흰쌀밥
+       (5, 10, 'REQUIRED'), -- 샐러드
+       (8, 10, 'OPTIONAL'), -- 샐러드
+       (11, 6, 'REQUIRED'), -- 피자
+       (12, 15, 'REQUIRED'), -- 새우볶음밥
+       (13, 15, 'OPTIONAL'), -- 새우볶음밥
+       (14, 12, 'REQUIRED'), -- 초콜릿 케이크
+       (15, 12, 'REQUIRED'), -- 초콜릿 케이크
+       (16, 13, 'REQUIRED'), -- 베지터블 스프
+       (17, 13, 'REQUIRED'), -- 베지터블 스프
+       (18, 14, 'OPTIONAL'); -- 카레라이스
+
+INSERT INTO recipe_step (recipe_id, image, description, sequence)
+VALUES (1, '레시피1 설명1 이미지', '레시피1 설명1', 1),
+       (1, '레시피1 설명3 이미지', '레시피1 설명3', 3),
+       (1, '레시피1 설명2 이미지', '레시피1 설명2', 2);

--- a/backend/src/test/resources/data/users.sql
+++ b/backend/src/test/resources/data/users.sql
@@ -1,9 +1,14 @@
 SET REFERENTIAL_INTEGRITY FALSE;
+
 TRUNCATE TABLE users;
 ALTER TABLE users ALTER COLUMN id RESTART WITH 1;
 
+TRUNCATE TABLE user_block;
+ALTER TABLE user_block ALTER COLUMN id RESTART WITH 1;
+
 TRUNCATE TABLE user_report;
 ALTER TABLE user_report ALTER COLUMN id RESTART WITH 1;
+
 SET REFERENTIAL_INTEGRITY TRUE;
 
 INSERT INTO users (email, username, nickname, image, region)
@@ -16,3 +21,6 @@ VALUES ('loki@pengcook.net', 'loki', '로키', 'loki.jpg', 'KOREA'),
        ('km@pengcook.net', 'km', '케이엠', 'km.jpg', 'KOREA'),
        ('hadi@pengcook.net', 'hadi', '하디', 'hadi.jpg', 'KOREA');
 
+INSERT INTO user_block (blocker_id, blockee_id)
+VALUES (1, 2),
+       (1, 3)


### PR DESCRIPTION
### 차단 유저 필터링

차단한 유저의 컨텐츠를 보이지 않게 하는 기능입니다.
pr에는 사용법 위주로 설명하고 동작방식은 오프라인 코드리뷰로 설명하겠습니다.

### 🔥🔥🔥사용법🔥🔥🔥
레포지토리에서 리턴되는 클래스가 작성자 필드가 있다면 `AuthorAble`을 구현해주면 됩니다.

```java
public interface AuthorAble {

    long getAuthorId();
}
```

> *예시*
>
> `RecipeRepository`의 `findRecipeData`이 `List<RecipeDataResponse>`을 리턴함
>
> ![스크린샷 2024-08-04 오후 4 07 23](https://github.com/user-attachments/assets/4dbd2f7e-0438-46ff-8cdd-a72f18c94952)
>
> RecipeDataResponse는 AuthorAble을 구현
>
> ![스크린샷 2024-08-04 오후 4 09 02](https://github.com/user-attachments/assets/566647ba-3cbb-405c-98b3-2bf92f90038c)
> 

### 주의사항
- 요청이 들어왔을때 `HttpServletRequest`에서 사용자의 정보를 가져오고 저장하므로 실제 요청이 있어야 작동합니다. (실제 요청 또는 `RestAssured`를 이용한 테스트에서만 블럭이 됨) 