### PR TITLE
⚡ prevent to run cd concurrently

### DIFF
--- a/.github/workflows/be-cd.yaml
+++ b/.github/workflows/be-cd.yaml
@@ -4,7 +4,10 @@ on:
   push:
     branches:
       - be/dev
-      - be/feat/95
+
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/be-ci.yaml
+++ b/.github/workflows/be-ci.yaml
@@ -5,6 +5,10 @@ on:
     branches:
       - be/dev
 
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### 기존 문제
`Github Actions` 에서 워크플루가 2개 이상 작동할 때 `CI` 쪽은 크게 문제가 없을 수도 있지만 `CD` 쪽에서 이전 버전의 배포가 최신 버전을 덮어 씌운 뒤 서버에 올라가는 동시성 문제가 있음

### 해결법
스크립트 자체에 `concurrency` 를 추가하여 새로운 `CD Workflow` 가 실행되면 이전의 `Workflow` 는 중지되도록 스크립트를 변경