### PR TITLE
🐛 prevent to cancel like many times

### DIFF
--- a/backend/src/main/java/net/pengcook/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/net/pengcook/exception/GlobalExceptionHandler.java
@@ -30,7 +30,9 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(DomainException.class)
     public ResponseEntity<ProblemDetail> handleDomainException(DomainException ex) {
-        log.error(ex.getMessage(), ex);
+        if (ex.getHttpStatus().is5xxServerError()) {
+            log.error(ex.getMessage(), ex);
+        }
 
         ProblemDetail problemDetail = ProblemDetail.forStatus(ex.getHttpStatus());
         problemDetail.setDetail(ex.getMessage());

--- a/backend/src/main/java/net/pengcook/like/controller/RecipeLikeController.java
+++ b/backend/src/main/java/net/pengcook/like/controller/RecipeLikeController.java
@@ -21,6 +21,7 @@ public class RecipeLikeController {
 
     private final RecipeLikeService likeService;
 
+    // TODO: add my like boolean field
     @GetMapping("/{recipeId}")
     public RecipeLikeResponse readLikesCount(@PathVariable("recipeId") long recipeId) {
         return likeService.readLikesCount(recipeId);
@@ -31,7 +32,7 @@ public class RecipeLikeController {
             @LoginUser UserInfo userInfo,
             @RequestBody @Valid RecipeLikeRequest likeRequest
     ) {
-        if (likeRequest.like()) {
+        if (likeRequest.isLike()) {
             likeService.addLike(userInfo, likeRequest.recipeId());
             return;
         }

--- a/backend/src/main/java/net/pengcook/like/controller/RecipeLikeController.java
+++ b/backend/src/main/java/net/pengcook/like/controller/RecipeLikeController.java
@@ -21,10 +21,12 @@ public class RecipeLikeController {
 
     private final RecipeLikeService likeService;
 
-    // TODO: add my like boolean field
     @GetMapping("/{recipeId}")
-    public RecipeLikeResponse readLikesCount(@PathVariable("recipeId") long recipeId) {
-        return likeService.readLikesCount(recipeId);
+    public RecipeLikeResponse readLikesCount(
+            @LoginUser UserInfo userInfo,
+            @PathVariable("recipeId") long recipeId
+    ) {
+        return likeService.readLikesCount(userInfo, recipeId);
     }
 
     @PostMapping

--- a/backend/src/main/java/net/pengcook/like/controller/RecipeLikeController.java
+++ b/backend/src/main/java/net/pengcook/like/controller/RecipeLikeController.java
@@ -22,7 +22,7 @@ public class RecipeLikeController {
     private final RecipeLikeService likeService;
 
     @GetMapping("/{recipeId}")
-    public RecipeLikeResponse readLikesCount(
+    public RecipeLikeResponse readLike(
             @LoginUser UserInfo userInfo,
             @PathVariable("recipeId") long recipeId
     ) {
@@ -30,7 +30,7 @@ public class RecipeLikeController {
     }
 
     @PostMapping
-    public void toggleLike(
+    public void updateLike(
             @LoginUser UserInfo userInfo,
             @RequestBody @Valid RecipeLikeRequest likeRequest
     ) {

--- a/backend/src/main/java/net/pengcook/like/controller/RecipeLikeController.java
+++ b/backend/src/main/java/net/pengcook/like/controller/RecipeLikeController.java
@@ -26,7 +26,7 @@ public class RecipeLikeController {
             @LoginUser UserInfo userInfo,
             @PathVariable("recipeId") long recipeId
     ) {
-        return likeService.readLikesCount(userInfo, recipeId);
+        return likeService.readLike(userInfo, recipeId);
     }
 
     @PostMapping

--- a/backend/src/main/java/net/pengcook/like/dto/RecipeLikeRequest.java
+++ b/backend/src/main/java/net/pengcook/like/dto/RecipeLikeRequest.java
@@ -1,4 +1,4 @@
 package net.pengcook.like.dto;
 
-public record RecipeLikeRequest(long recipeId, boolean like) {
+public record RecipeLikeRequest(long recipeId, boolean isLike) {
 }

--- a/backend/src/main/java/net/pengcook/like/dto/RecipeLikeResponse.java
+++ b/backend/src/main/java/net/pengcook/like/dto/RecipeLikeResponse.java
@@ -1,4 +1,4 @@
 package net.pengcook.like.dto;
 
-public record RecipeLikeResponse(int likesCount) {
+public record RecipeLikeResponse(int likesCount, boolean isLike) {
 }

--- a/backend/src/main/java/net/pengcook/like/dto/RecipeLikeResponse.java
+++ b/backend/src/main/java/net/pengcook/like/dto/RecipeLikeResponse.java
@@ -1,4 +1,4 @@
 package net.pengcook.like.dto;
 
-public record RecipeLikeResponse(int likesCount, boolean isLike) {
+public record RecipeLikeResponse(boolean isLike) {
 }

--- a/backend/src/main/java/net/pengcook/like/repository/RecipeLikeRepository.java
+++ b/backend/src/main/java/net/pengcook/like/repository/RecipeLikeRepository.java
@@ -1,12 +1,11 @@
 package net.pengcook.like.repository;
 
-import java.util.Optional;
 import net.pengcook.like.domain.RecipeLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RecipeLikeRepository extends JpaRepository<RecipeLike, Long> {
 
-    Optional<RecipeLike> findByUserIdAndRecipeId(long userId, long recipeId);
+    boolean existsByUserIdAndRecipeId(long userId, long recipeId);
 
     void deleteByUserIdAndRecipeId(long userId, long recipeId);
 }

--- a/backend/src/main/java/net/pengcook/like/service/RecipeLikeService.java
+++ b/backend/src/main/java/net/pengcook/like/service/RecipeLikeService.java
@@ -22,13 +22,14 @@ public class RecipeLikeService {
     private final UserRepository userRepository;
     private final RecipeRepository recipeRepository;
 
-    public RecipeLikeResponse readLikesCount(long recipeId) {
+    public RecipeLikeResponse readLikesCount(UserInfo userInfo, long recipeId) {
         int likesCount = recipeRepository.findById(recipeId).stream()
                 .mapToInt(Recipe::getLikeCount)
                 .findAny()
                 .orElseThrow(RecipeNotFoundException::new);
+        boolean isLike = likeRepository.existsByUserIdAndRecipeId(userInfo.getId(), recipeId);
 
-        return new RecipeLikeResponse(likesCount);
+        return new RecipeLikeResponse(likesCount, isLike);
     }
 
     @Transactional
@@ -50,7 +51,7 @@ public class RecipeLikeService {
 
     @Transactional
     public void deleteLike(UserInfo userInfo, long recipeId) {
-        if (likeRepository.existsByUserIdAndRecipeId(userInfo.getId(), recipeId)) {
+        if (!likeRepository.existsByUserIdAndRecipeId(userInfo.getId(), recipeId)) {
             return;
         }
 

--- a/backend/src/main/java/net/pengcook/like/service/RecipeLikeService.java
+++ b/backend/src/main/java/net/pengcook/like/service/RecipeLikeService.java
@@ -22,14 +22,10 @@ public class RecipeLikeService {
     private final UserRepository userRepository;
     private final RecipeRepository recipeRepository;
 
-    public RecipeLikeResponse readLikesCount(UserInfo userInfo, long recipeId) {
-        int likesCount = recipeRepository.findById(recipeId).stream()
-                .mapToInt(Recipe::getLikeCount)
-                .findAny()
-                .orElseThrow(RecipeNotFoundException::new);
+    public RecipeLikeResponse readLike(UserInfo userInfo, long recipeId) {
         boolean isLike = likeRepository.existsByUserIdAndRecipeId(userInfo.getId(), recipeId);
 
-        return new RecipeLikeResponse(likesCount, isLike);
+        return new RecipeLikeResponse(isLike);
     }
 
     @Transactional

--- a/backend/src/main/java/net/pengcook/like/service/RecipeLikeService.java
+++ b/backend/src/main/java/net/pengcook/like/service/RecipeLikeService.java
@@ -33,6 +33,10 @@ public class RecipeLikeService {
 
     @Transactional
     public void addLike(UserInfo userInfo, long recipeId) {
+        if (likeRepository.existsByUserIdAndRecipeId(userInfo.getId(), recipeId)) {
+            return;
+        }
+
         User user = userRepository.findById(userInfo.getId())
                 .orElseThrow(UserNotFoundException::new);
         Recipe recipe = recipeRepository.findById(recipeId)
@@ -46,6 +50,10 @@ public class RecipeLikeService {
 
     @Transactional
     public void deleteLike(UserInfo userInfo, long recipeId) {
+        if (likeRepository.existsByUserIdAndRecipeId(userInfo.getId(), recipeId)) {
+            return;
+        }
+
         Recipe recipe = recipeRepository.findById(recipeId)
                 .orElseThrow(RecipeNotFoundException::new);
 

--- a/backend/src/test/java/net/pengcook/like/controller/RecipeLikeControllerTest.java
+++ b/backend/src/test/java/net/pengcook/like/controller/RecipeLikeControllerTest.java
@@ -25,12 +25,12 @@ class RecipeLikeControllerTest extends RestDocsSetting {
 
     @Test
     @WithLoginUser(email = "ela@pengcook.net")
-    @DisplayName("게시글의 좋아요 개수를 조회한다.")
+    @DisplayName("게시글의 좋아요 여부를 조회한다.")
     void readLike() {
         RestAssured.given(spec).log().all()
                 .filter(document(DEFAULT_RESTDOCS_PATH,
-                        "특정 레시피의 좋아요 개수를 조회한다.",
-                        "레시피별 좋아요 개수 조회 API",
+                        "특정 레시피의 좋아요 여부를 조회한다.",
+                        "레시피별 좋아요 여부 조회 API",
                         pathParameters(
                                 parameterWithName("recipeId").description("레시피 아이디")
                         ),

--- a/backend/src/test/java/net/pengcook/like/controller/RecipeLikeControllerTest.java
+++ b/backend/src/test/java/net/pengcook/like/controller/RecipeLikeControllerTest.java
@@ -24,6 +24,7 @@ import org.springframework.test.context.jdbc.Sql;
 class RecipeLikeControllerTest extends RestDocsSetting {
 
     @Test
+    @WithLoginUser(email = "ela@pengcook.net")
     @DisplayName("게시글의 좋아요 개수를 조회한다.")
     void readLikesCount() {
         RestAssured.given(spec).log().all()
@@ -34,7 +35,8 @@ class RecipeLikeControllerTest extends RestDocsSetting {
                                 parameterWithName("recipeId").description("레시피 아이디")
                         ),
                         responseFields(
-                                fieldWithPath("likesCount").description("좋아요 개수")
+                                fieldWithPath("likesCount").description("좋아요 개수"),
+                                fieldWithPath("isLike").description("나의 좋아요 여부")
                         )))
                 .when().get("/api/likes/{recipeId}", 1L)
                 .then().log().all()
@@ -52,7 +54,7 @@ class RecipeLikeControllerTest extends RestDocsSetting {
                         "레시피별 좋아요 변경 API",
                         requestFields(
                                 fieldWithPath("recipeId").description("레시피 아이디"),
-                                fieldWithPath("isLike").description("좋아요 여부")
+                                fieldWithPath("isLike").description("나의 좋아요 여부")
                         )))
                 .body(Map.of("recipeId", 2L, "isLike", true))
                 .contentType(ContentType.JSON)

--- a/backend/src/test/java/net/pengcook/like/controller/RecipeLikeControllerTest.java
+++ b/backend/src/test/java/net/pengcook/like/controller/RecipeLikeControllerTest.java
@@ -26,7 +26,7 @@ class RecipeLikeControllerTest extends RestDocsSetting {
     @Test
     @WithLoginUser(email = "ela@pengcook.net")
     @DisplayName("게시글의 좋아요 개수를 조회한다.")
-    void readLikesCount() {
+    void readLike() {
         RestAssured.given(spec).log().all()
                 .filter(document(DEFAULT_RESTDOCS_PATH,
                         "특정 레시피의 좋아요 개수를 조회한다.",
@@ -35,13 +35,12 @@ class RecipeLikeControllerTest extends RestDocsSetting {
                                 parameterWithName("recipeId").description("레시피 아이디")
                         ),
                         responseFields(
-                                fieldWithPath("likesCount").description("좋아요 개수"),
                                 fieldWithPath("isLike").description("나의 좋아요 여부")
                         )))
                 .when().get("/api/likes/{recipeId}", 1L)
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
-                .body("likesCount", is(1));
+                .body("isLike", is(true));
     }
 
     @Test

--- a/backend/src/test/java/net/pengcook/like/controller/RecipeLikeControllerTest.java
+++ b/backend/src/test/java/net/pengcook/like/controller/RecipeLikeControllerTest.java
@@ -28,6 +28,8 @@ class RecipeLikeControllerTest extends RestDocsSetting {
     void readLikesCount() {
         RestAssured.given(spec).log().all()
                 .filter(document(DEFAULT_RESTDOCS_PATH,
+                        "특정 레시피의 좋아요 개수를 조회한다.",
+                        "레시피별 좋아요 개수 조회 API",
                         pathParameters(
                                 parameterWithName("recipeId").description("레시피 아이디")
                         ),
@@ -50,9 +52,9 @@ class RecipeLikeControllerTest extends RestDocsSetting {
                         "레시피별 좋아요 변경 API",
                         requestFields(
                                 fieldWithPath("recipeId").description("레시피 아이디"),
-                                fieldWithPath("like").description("좋아요 여부")
+                                fieldWithPath("isLike").description("좋아요 여부")
                         )))
-                .body(Map.of("recipeId", 2L, "like", true))
+                .body(Map.of("recipeId", 2L, "isLike", true))
                 .contentType(ContentType.JSON)
                 .when().post("/api/likes")
                 .then().log().all()
@@ -69,9 +71,9 @@ class RecipeLikeControllerTest extends RestDocsSetting {
                         "레시피별 좋아요 변경 API",
                         requestFields(
                                 fieldWithPath("recipeId").description("레시피 아이디"),
-                                fieldWithPath("like").description("좋아요 여부")
+                                fieldWithPath("isLike").description("좋아요 여부")
                         )))
-                .body(Map.of("recipeId", 1L, "like", false))
+                .body(Map.of("recipeId", 1L, "isLike", false))
                 .contentType(ContentType.JSON)
                 .when().post("/api/likes")
                 .then().log().all()

--- a/backend/src/test/java/net/pengcook/like/service/RecipeLikeServiceTest.java
+++ b/backend/src/test/java/net/pengcook/like/service/RecipeLikeServiceTest.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import net.pengcook.authentication.domain.UserInfo;
 import net.pengcook.like.exception.RecipeLikeException;
+import net.pengcook.like.exception.RecipeNotFoundException;
+import net.pengcook.like.exception.UserNotFoundException;
 import net.pengcook.like.repository.RecipeLikeRepository;
 import net.pengcook.recipe.repository.RecipeRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -24,16 +26,15 @@ class RecipeLikeServiceTest {
     @Autowired
     private RecipeLikeRepository likeRepository;
     @Autowired
-    private RecipeRepository RecipeRepository;
-    @Autowired
     private RecipeRepository recipeRepository;
 
     @Test
     @DisplayName("레시피의 좋아요 개수 1개를 조회한다.")
     void readLikesCountOne() {
+        UserInfo userInfo = new UserInfo(1L, "ela@pengcook.net");
         long recipeId = 1L;
 
-        int likesCount = recipeLikeService.readLikesCount(recipeId).likesCount();
+        int likesCount = recipeLikeService.readLikesCount(userInfo, recipeId).likesCount();
 
         assertThat(likesCount).isOne();
     }
@@ -41,9 +42,10 @@ class RecipeLikeServiceTest {
     @Test
     @DisplayName("레시피의 좋아요 개수 0개를 조회한다.")
     void readLikesCountZero() {
+        UserInfo userInfo = new UserInfo(1L, "ela@pengcook.net");
         long recipeId = 2L;
 
-        int likesCount = recipeLikeService.readLikesCount(recipeId).likesCount();
+        int likesCount = recipeLikeService.readLikesCount(userInfo, recipeId).likesCount();
 
         assertThat(likesCount).isZero();
     }
@@ -51,9 +53,10 @@ class RecipeLikeServiceTest {
     @Test
     @DisplayName("존재하지 않는 레시피에 좋아요를 조회할 경우 예외가 발생한다.")
     void readLikesWhenNotExistRecipe() {
+        UserInfo userInfo = new UserInfo(1L, "ela@pengcook.net");
         long recipeId = 7L;
 
-        assertThatThrownBy(() -> recipeLikeService.readLikesCount(recipeId))
+        assertThatThrownBy(() -> recipeLikeService.readLikesCount(userInfo, recipeId))
                 .isInstanceOf(RecipeLikeException.class)
                 .hasMessage("존재하지 않는 레시피 입니다.");
     }
@@ -119,24 +122,22 @@ class RecipeLikeServiceTest {
     }
 
     @Test
-    @DisplayName("존재하지 않는 유저가 레시피의 좋아요를 변경할 경우 예외가 발생한다.")
-    void toggleLikeWhenNotExistUser() {
+    @DisplayName("존재하지 않는 유저가 레시피의 좋아요를 추가할 경우 예외가 발생한다.")
+    void addLikeWhenNotExistUser() {
         UserInfo userInfo = new UserInfo(4L, "seyang@pengcook.net");
         long recipeId = 1L;
 
         assertThatThrownBy(() -> recipeLikeService.addLike(userInfo, recipeId))
-                .isInstanceOf(RecipeLikeException.class)
-                .hasMessage("존재하지 않는 유저 입니다.");
+                .isInstanceOf(UserNotFoundException.class);
     }
 
     @Test
-    @DisplayName("존재하지 않는 레시피에 대해 좋아요를 변경할 경우 예외가 발생한다.")
-    void toggleLikeWhenNotExistRecipe() {
+    @DisplayName("존재하지 않는 레시피에 대해 좋아요를 추가할 경우 예외가 발생한다.")
+    void addLikeWhenNotExistRecipe() {
         UserInfo userInfo = new UserInfo(1L, "ela@pengcook.net");
         long recipeId = 7L;
 
-        assertThatThrownBy(() -> recipeLikeService.deleteLike(userInfo, recipeId))
-                .isInstanceOf(RecipeLikeException.class)
-                .hasMessage("존재하지 않는 레시피 입니다.");
+        assertThatThrownBy(() -> recipeLikeService.addLike(userInfo, recipeId))
+                .isInstanceOf(RecipeNotFoundException.class);
     }
 }

--- a/backend/src/test/java/net/pengcook/like/service/RecipeLikeServiceTest.java
+++ b/backend/src/test/java/net/pengcook/like/service/RecipeLikeServiceTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import net.pengcook.authentication.domain.UserInfo;
-import net.pengcook.like.exception.RecipeLikeException;
 import net.pengcook.like.exception.RecipeNotFoundException;
 import net.pengcook.like.exception.UserNotFoundException;
 import net.pengcook.like.repository.RecipeLikeRepository;
@@ -29,36 +28,25 @@ class RecipeLikeServiceTest {
     private RecipeRepository recipeRepository;
 
     @Test
-    @DisplayName("레시피의 좋아요 개수 1개를 조회한다.")
-    void readLikesCountOne() {
+    @DisplayName("내가 좋아요를 한 게시글인지 조회한다.")
+    void readLikeMine() {
         UserInfo userInfo = new UserInfo(1L, "ela@pengcook.net");
         long recipeId = 1L;
 
-        int likesCount = recipeLikeService.readLikesCount(userInfo, recipeId).likesCount();
+        boolean like = recipeLikeService.readLike(userInfo, recipeId).isLike();
 
-        assertThat(likesCount).isOne();
+        assertThat(like).isTrue();
     }
 
     @Test
-    @DisplayName("레시피의 좋아요 개수 0개를 조회한다.")
-    void readLikesCountZero() {
+    @DisplayName("내가 좋아요를 하지 않은 게시글인지 조회한다.")
+    void readLikeNotMine() {
         UserInfo userInfo = new UserInfo(1L, "ela@pengcook.net");
         long recipeId = 2L;
 
-        int likesCount = recipeLikeService.readLikesCount(userInfo, recipeId).likesCount();
+        boolean like = recipeLikeService.readLike(userInfo, recipeId).isLike();
 
-        assertThat(likesCount).isZero();
-    }
-
-    @Test
-    @DisplayName("존재하지 않는 레시피에 좋아요를 조회할 경우 예외가 발생한다.")
-    void readLikesWhenNotExistRecipe() {
-        UserInfo userInfo = new UserInfo(1L, "ela@pengcook.net");
-        long recipeId = 7L;
-
-        assertThatThrownBy(() -> recipeLikeService.readLikesCount(userInfo, recipeId))
-                .isInstanceOf(RecipeLikeException.class)
-                .hasMessage("존재하지 않는 레시피 입니다.");
+        assertThat(like).isFalse();
     }
 
     @Test


### PR DESCRIPTION
### 문제점
- 좋아요 취소 요청이 무한으로 요청되어 좋아요가 `-n` 까지 내려가는 문제 발생

### 해결과정
- 아래 4가지 상황을 모두 개수와 함께 테스트
  - 좋아요 안한 게시글에 좋아요
  - 좋아요 안한 게시글에 좋아요 취소
  - 좋아요 한 게시글에 좋아요
  - 좋아요 한 게시글에 좋아요 취소

### 추가사항
- 추가로, 모든 `DomainException` 에 대해 `4xx` `Http Status Code` 임에도 불구하고 로깅을 하는 것을 `5xx` 코드에 대해서만 로깅하도록 수정하였습니다.
- 게시글 개요 조회 시 `likesCount` 가 보이기 때문에 `/likes/{recipeId}` 는 자기자신의 좋아요인지 확인하는 `API` 로 수정하였습니다.