### PR TITLE
:sparkles: change server tz and open container db port

### DIFF
--- a/backend/src/main/resources/application-dev.yaml
+++ b/backend/src/main/resources/application-dev.yaml
@@ -1,7 +1,7 @@
 spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: ENC(eIHB8scXoPToXALlbQfBUAT5537K5jnGDPFooUq7HMmSFR3vdr9CwXRaaZUpmAP0psZTMcTPscwDOY/Ljlemkx67yfZjBLkPC/FapC/qY3RqLnoI4cbFSdZw2y4LzRt8iWqBeyDtCWgHwlQSrX3X3A==)
+    url: ENC(MDL1AcKr9jd9NRO0JRWgHNDzVTUDZMZSPrhv/F8Zgr9+fnvvd53pALeR8UrcLhDyB4Tw8PDLZZc1+uR2WWIt2m7dB1zk6/xUlEBz7WTi+98WosqWWIwC/80iqnWVlNHFlZoqky5c2PEp1qxHl9pAUQ==)
     username: ENC(M4z9d3ZA9vsM6dszL8Irp4CYS8QPZagRCFt/aDcKd/JzPLp3cm4os0N4Q1UsoTEf)
     password: ENC(XgbKU4yM/P3edIbLl9SysxhawJySVlO5f2BBihSvS0l9wSxywr3lPpApgFIEjCEu)
 

--- a/backend/src/main/resources/application-local.yaml
+++ b/backend/src/main/resources/application-local.yaml
@@ -1,7 +1,7 @@
 spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost/pengcook?characterEncoding=UTF-8&serverTimezone=UTC
+    url: jdbc:mysql://localhost/pengcook?characterEncoding=UTF-8&serverTimezone=Asia/Seoul
     username: root
     password: root
 

--- a/backend/src/main/resources/docker-compose-dev.yaml
+++ b/backend/src/main/resources/docker-compose-dev.yaml
@@ -25,6 +25,7 @@ services:
     restart: unless-stopped
     environment:
       JASYPT_PASSWORD: ${JASYPT_PASSWORD}
+      TZ: Asia/Seoul
     ports:
       - 8080:8080
     links:

--- a/backend/src/main/resources/docker-compose-dev.yaml
+++ b/backend/src/main/resources/docker-compose-dev.yaml
@@ -11,8 +11,11 @@ services:
       MYSQL_DATABASE: ${MYSQL_DATABASE}
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
       LANG: C.UTF-8
+      TZ: Asia/Seoul
     volumes:
       - db:/var/lib/mysql
+    ports:
+      - 3306:3306
     command:
       - --character-set-server=utf8
       - --collation-server=utf8_general_ci

--- a/backend/src/main/resources/docker-compose-local.yaml
+++ b/backend/src/main/resources/docker-compose-local.yaml
@@ -11,6 +11,7 @@ services:
       MYSQL_DATABASE: pengcook
       MYSQL_ROOT_PASSWORD: root
       LANG: C.UTF-8
+      TZ: Asia/Seoul
     volumes:
       - db:/var/lib/mysql
     ports:


### PR DESCRIPTION
### 반영 사항
- 새로운 `CD` 가 작동되어 서버로 반영될 때 마다 `3306` 포트가 닫혀버려서 `docker-compose-dev.yaml` 파일에 `port` 속성을 추가했습니다!
- 또한 `db` 쪽 환경변수로 `timezone` 을 `TZ` 로 설정하여 db에 반영되도록 하였습니다.
- `Spring Boot` 실행 쪽에서도 현구막 블로그를 보며 컨테이너에 `TZ` 환경변수를 지정하였습니다.

### 테스트
- 로컬 `docker compose` 를 재시작 하여 `select now();` 쿼리를 실행하여 DB에서 현재 시간이 언제로 나오는지 체크해보았습니다.