### PR TITLE
🐛 fix navigation error and viewmodel logic errors

### DIFF
--- a/android/app/src/main/java/net/pengcook/android/presentation/making/step/StepMakingFragment.kt
+++ b/android/app/src/main/java/net/pengcook/android/presentation/making/step/StepMakingFragment.kt
@@ -8,6 +8,7 @@ import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import androidx.navigation.ui.navigateUp
 import net.pengcook.android.databinding.FragmentMakingStepBinding
 import net.pengcook.android.presentation.DefaultPengcookApplication
 
@@ -80,7 +81,7 @@ class StepMakingFragment : Fragment() {
     private fun observeQuitStepMakingState() {
         viewModel.quitStepMakingState.observe(viewLifecycleOwner) { event ->
             event.getContentIfNotHandled()?.let {
-                findNavController().popBackStack()
+                findNavController().navigateUp()
             }
         }
     }
@@ -88,9 +89,8 @@ class StepMakingFragment : Fragment() {
     private fun observeCompleteStepMakingState() {
         viewModel.completeStepMakingState.observe(viewLifecycleOwner) { event ->
             event.getContentIfNotHandled()?.let {
-                // Seems like legacy code
-                findNavController().popBackStack()
-                findNavController().popBackStack()
+                val action = StepMakingFragmentDirections.actionStepMakingFragmentToHomeFragment()
+                findNavController().navigate(action)
             }
         }
     }

--- a/android/app/src/main/java/net/pengcook/android/presentation/making/step/StepMakingViewModel.kt
+++ b/android/app/src/main/java/net/pengcook/android/presentation/making/step/StepMakingViewModel.kt
@@ -94,7 +94,7 @@ class StepMakingViewModel(
     }
 
     override fun customAction() {
-        if (isIntroductionContentEmpty.value == true) {
+        if (introductionContent.value.isNullOrEmpty()) {
             _emptyIntroductionState.value = Event(true)
             return
         }

--- a/android/app/src/main/res/navigation/nav_graph.xml
+++ b/android/app/src/main/res/navigation/nav_graph.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/nav_graph"
-    app:startDestination="@id/homeFragment">
+    app:startDestination="@id/onboardingFragment">
 
     <fragment
         android:id="@+id/homeFragment"
@@ -48,6 +48,8 @@
 
         <action
             android:id="@+id/action_onboardingFragment_to_homeFragment"
+            app:popUpTo="@id/onboardingFragment"
+            app:popUpToInclusive="true"
             app:destination="@id/homeFragment" />
     </fragment>
 
@@ -130,6 +132,17 @@
         <argument
             android:name="recipeId"
             app:argType="long" />
+        <action
+            android:id="@+id/action_stepMakingFragment_to_recipeMakingFragment"
+            app:popUpTo="@id/stepMakingFragment"
+            app:popUpToInclusive="true"
+            />
+        <action
+            android:id="@+id/action_stepMakingFragment_to_homeFragment"
+            app:destination="@id/homeFragment"
+            app:popUpTo="@id/homeFragment"
+            app:popUpToInclusive="true"
+            />
     </fragment>
 
 

--- a/android/app/src/test/java/net/pengcook/android/presentation/making/step/StepMakingViewModelTest.kt
+++ b/android/app/src/test/java/net/pengcook/android/presentation/making/step/StepMakingViewModelTest.kt
@@ -213,7 +213,7 @@ class StepMakingViewModelTest {
         // introduction이 비어있을 때 emptyIntroductionState가 호출되는지 테스트
         runTest {
             // given
-            viewModel = StepMakingViewModel(1, 15, stepMakingRepository)
+            viewModel = StepMakingViewModel(2, 15, stepMakingRepository)
             advanceUntilIdle()
 
             // when
@@ -256,8 +256,9 @@ class StepMakingViewModelTest {
         // introduction이 비어있을 때 스텝 제작을 완료할 수 없는지 테스트
         runTest {
             // given
-            viewModel = StepMakingViewModel(1, 15, stepMakingRepository)
+            viewModel = StepMakingViewModel(2, 15, stepMakingRepository)
             advanceUntilIdle()
+            assertEquals("", viewModel.introductionContent.getOrAwaitValue())
 
             // when
             viewModel.customAction()


### PR DESCRIPTION
🐛  navigation error
- before: navigation action of making step
- after: making step Fragment-> back press ; (navigateUp call) -> making recipe Fragment
             making step Fragment -> press "X" button; -> move to "Home(Feed) Fragment

- before : when back pressed on Home Fragment, Onboarding fragment showed.
- after : when back pressed on Home Fragment, app closed.

🐛  viewmodel logic error (StepMakingViewModel)
- before : impossible to complete making recipe when it is on first step
- after: only impossible when the introduction is empty