### PR TITLE
♻️ modify recipe step creation validation

### DIFF
--- a/backend/src/main/java/net/pengcook/recipe/controller/RecipeController.java
+++ b/backend/src/main/java/net/pengcook/recipe/controller/RecipeController.java
@@ -14,6 +14,7 @@ import net.pengcook.recipe.dto.RecipeResponse;
 import net.pengcook.recipe.dto.RecipeStepRequest;
 import net.pengcook.recipe.dto.RecipeStepResponse;
 import net.pengcook.recipe.service.RecipeService;
+import net.pengcook.recipe.service.RecipeStepService;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -30,6 +31,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class RecipeController {
 
     private final RecipeService recipeService;
+    private final RecipeStepService recipeStepService;
 
     @GetMapping
     public List<MainRecipeResponse> readRecipes(@ModelAttribute @Valid PageRecipeRequest pageRecipeRequest) {
@@ -40,25 +42,6 @@ public class RecipeController {
     @ResponseStatus(HttpStatus.CREATED)
     public RecipeResponse createRecipe(@LoginUser UserInfo userInfo, @RequestBody @Valid RecipeRequest recipeRequest) {
         return recipeService.createRecipe(userInfo, recipeRequest);
-    }
-
-    @GetMapping("/{recipeId}/steps")
-    public List<RecipeStepResponse> readRecipeSteps(@PathVariable long recipeId) {
-        return recipeService.readRecipeSteps(recipeId);
-    }
-
-    @GetMapping("/{recipeId}/steps/{sequence}")
-    public RecipeStepResponse readRecipeStep(@PathVariable long recipeId, @PathVariable long sequence) {
-        return recipeService.readRecipeStep(recipeId, sequence);
-    }
-
-    @PostMapping("/{recipeId}/steps")
-    @ResponseStatus(HttpStatus.CREATED)
-    public RecipeStepResponse createRecipeStep(
-            @PathVariable long recipeId,
-            @RequestBody @Valid RecipeStepRequest recipeStepRequest
-    ) {
-        return recipeService.createRecipeStep(recipeId, recipeStepRequest);
     }
 
     @GetMapping("/search")
@@ -75,4 +58,22 @@ public class RecipeController {
         return recipeService.readRecipesOfUser(recipeOfUserRequest);
     }
 
+    @GetMapping("/{recipeId}/steps")
+    public List<RecipeStepResponse> readRecipeSteps(@PathVariable long recipeId) {
+        return recipeStepService.readRecipeSteps(recipeId);
+    }
+
+    @GetMapping("/{recipeId}/steps/{sequence}")
+    public RecipeStepResponse readRecipeStep(@PathVariable long recipeId, @PathVariable long sequence) {
+        return recipeStepService.readRecipeStep(recipeId, sequence);
+    }
+
+    @PostMapping("/{recipeId}/steps")
+    @ResponseStatus(HttpStatus.CREATED)
+    public RecipeStepResponse createRecipeStep(
+            @PathVariable long recipeId,
+            @RequestBody @Valid RecipeStepRequest recipeStepRequest
+    ) {
+        return recipeStepService.createRecipeStep(recipeId, recipeStepRequest);
+    }
 }

--- a/backend/src/main/java/net/pengcook/recipe/domain/RecipeStep.java
+++ b/backend/src/main/java/net/pengcook/recipe/domain/RecipeStep.java
@@ -43,7 +43,7 @@ public class RecipeStep {
     }
 
     public RecipeStep update(String imageUrl, String description, LocalTime cookingTime) {
-        this.image  = imageUrl;
+        this.image = imageUrl;
         this.description = description;
         this.cookingTime = cookingTime;
 

--- a/backend/src/main/java/net/pengcook/recipe/dto/RecipeStepRequest.java
+++ b/backend/src/main/java/net/pengcook/recipe/dto/RecipeStepRequest.java
@@ -7,6 +7,6 @@ public record RecipeStepRequest(
         String image,
         @NotBlank String description,
         @Positive int sequence,
-        @NotBlank String cookingTime
+        String cookingTime
 ) {
 }

--- a/backend/src/main/java/net/pengcook/recipe/service/RecipeService.java
+++ b/backend/src/main/java/net/pengcook/recipe/service/RecipeService.java
@@ -199,8 +199,11 @@ public class RecipeService {
         }
     }
 
-    private RecipeStep saveRecipeStep(Recipe recipe, String imageUrl, RecipeStepRequest recipeStepRequest,
-                                      LocalTime cookingTime) {
+    private RecipeStep saveRecipeStep(
+            Recipe recipe, String imageUrl,
+            RecipeStepRequest recipeStepRequest,
+            LocalTime cookingTime
+    ) {
         RecipeStep recipeStep = new RecipeStep(
                 recipe,
                 imageUrl,

--- a/backend/src/main/java/net/pengcook/recipe/service/RecipeService.java
+++ b/backend/src/main/java/net/pengcook/recipe/service/RecipeService.java
@@ -1,6 +1,7 @@
 package net.pengcook.recipe.service;
 
 import java.time.LocalTime;
+import java.time.format.DateTimeParseException;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
@@ -95,7 +96,7 @@ public class RecipeService {
         Recipe recipe = getRecipeByRecipeId(recipeId);
         String imageUrl = getImageUrl(recipeStepRequest.image());
         String description = recipeStepRequest.description();
-        LocalTime cookingTime = LocalTime.parse(recipeStepRequest.cookingTime());
+        LocalTime cookingTime = getCookingTime(recipeStepRequest.cookingTime());
 
         Optional<RecipeStep> existingRecipeStep = recipeStepRepository.findByRecipeIdAndSequence(
                 recipeId,
@@ -219,5 +220,15 @@ public class RecipeService {
             throw new InvalidParameterException("적절하지 않은 이미지 이름입니다.");
         }
         return s3ClientService.getImageUrl(image).url();
+    }
+
+    private LocalTime getCookingTime(String cookingTime) {
+        try {
+            return Optional.ofNullable(cookingTime)
+                    .map(LocalTime::parse)
+                    .orElse(null);
+        } catch (DateTimeParseException exception) {
+            throw new InvalidParameterException("적절하지 않은 조리시간입니다.");
+        }
     }
 }

--- a/backend/src/main/java/net/pengcook/recipe/service/RecipeService.java
+++ b/backend/src/main/java/net/pengcook/recipe/service/RecipeService.java
@@ -1,11 +1,9 @@
 package net.pengcook.recipe.service;
 
 import java.time.LocalTime;
-import java.time.format.DateTimeParseException;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import net.pengcook.authentication.domain.UserInfo;
@@ -15,7 +13,6 @@ import net.pengcook.category.service.CategoryService;
 import net.pengcook.image.service.S3ClientService;
 import net.pengcook.ingredient.service.IngredientService;
 import net.pengcook.recipe.domain.Recipe;
-import net.pengcook.recipe.domain.RecipeStep;
 import net.pengcook.recipe.dto.AuthorResponse;
 import net.pengcook.recipe.dto.CategoryResponse;
 import net.pengcook.recipe.dto.IngredientResponse;
@@ -25,12 +22,8 @@ import net.pengcook.recipe.dto.RecipeDataResponse;
 import net.pengcook.recipe.dto.RecipeOfUserRequest;
 import net.pengcook.recipe.dto.RecipeRequest;
 import net.pengcook.recipe.dto.RecipeResponse;
-import net.pengcook.recipe.dto.RecipeStepRequest;
-import net.pengcook.recipe.dto.RecipeStepResponse;
 import net.pengcook.recipe.exception.InvalidParameterException;
-import net.pengcook.recipe.exception.NotFoundException;
 import net.pengcook.recipe.repository.RecipeRepository;
-import net.pengcook.recipe.repository.RecipeStepRepository;
 import net.pengcook.user.domain.User;
 import net.pengcook.user.repository.UserRepository;
 import org.springframework.data.domain.PageRequest;
@@ -44,7 +37,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class RecipeService {
 
     private final RecipeRepository recipeRepository;
-    private final RecipeStepRepository recipeStepRepository;
     private final CategoryRecipeRepository categoryRecipeRepository;
     private final UserRepository userRepository;
 
@@ -53,7 +45,7 @@ public class RecipeService {
     private final S3ClientService s3ClientService;
 
     public List<MainRecipeResponse> readRecipes(PageRecipeRequest pageRecipeRequest) {
-        Pageable pageable = getPageable(pageRecipeRequest.pageNumber(), pageRecipeRequest.pageSize());
+        Pageable pageable = getValidatedPageable(pageRecipeRequest.pageNumber(), pageRecipeRequest.pageSize());
         List<Long> recipeIds = recipeRepository.findRecipeIds(pageable);
 
         List<RecipeDataResponse> recipeDataResponses = recipeRepository.findRecipeData(recipeIds);
@@ -79,40 +71,9 @@ public class RecipeService {
         return new RecipeResponse(savedRecipe);
     }
 
-    public List<RecipeStepResponse> readRecipeSteps(long recipeId) {
-        List<RecipeStep> recipeSteps = recipeStepRepository.findAllByRecipeIdOrderBySequence(recipeId);
-        return convertToRecipeStepResponses(recipeSteps);
-    }
-
-    public RecipeStepResponse readRecipeStep(long recipeId, long sequence) {
-        RecipeStep recipeStep = recipeStepRepository.findByRecipeIdAndSequence(recipeId, sequence)
-                .orElseThrow(() -> new NotFoundException("해당되는 레시피 스텝 정보가 없습니다."));
-
-        return new RecipeStepResponse(recipeStep);
-    }
-
-    public RecipeStepResponse createRecipeStep(long recipeId, RecipeStepRequest recipeStepRequest) {
-        validateRecipeStepSequence(recipeId, recipeStepRequest.sequence());
-        Recipe recipe = getRecipeByRecipeId(recipeId);
-        String imageUrl = getValidatedImageUrl(recipeStepRequest.image());
-        String description = recipeStepRequest.description();
-        LocalTime cookingTime = getValidatedCookingTime(recipeStepRequest.cookingTime());
-
-        Optional<RecipeStep> existingRecipeStep = recipeStepRepository.findByRecipeIdAndSequence(
-                recipeId,
-                recipeStepRequest.sequence()
-        );
-
-        RecipeStep recipeStep = existingRecipeStep
-                .map(currentRecipeStep -> currentRecipeStep.update(imageUrl, description, cookingTime))
-                .orElseGet(() -> saveRecipeStep(recipe, imageUrl, recipeStepRequest, cookingTime));
-
-        return new RecipeStepResponse(recipeStep);
-    }
-
     public List<MainRecipeResponse> readRecipesOfCategory(RecipeOfCategoryRequest request) {
         String categoryName = request.category();
-        Pageable pageable = getPageable(request.pageNumber(), request.pageSize());
+        Pageable pageable = getValidatedPageable(request.pageNumber(), request.pageSize());
         List<Long> recipeIds = categoryRecipeRepository.findRecipeIdsByCategoryName(categoryName, pageable);
 
         List<RecipeDataResponse> recipeDataResponses = recipeRepository.findRecipeData(recipeIds);
@@ -121,17 +82,11 @@ public class RecipeService {
 
     public List<MainRecipeResponse> readRecipesOfUser(RecipeOfUserRequest request) {
         long userId = request.userId();
-        Pageable pageable = getPageable(request.pageNumber(), request.pageSize());
+        Pageable pageable = getValidatedPageable(request.pageNumber(), request.pageSize());
         List<Long> recipeIds = recipeRepository.findRecipeIdsByUserId(userId, pageable);
 
         List<RecipeDataResponse> recipeDataResponses = recipeRepository.findRecipeData(recipeIds);
         return convertToMainRecipeResponses(recipeDataResponses);
-    }
-
-    private List<RecipeStepResponse> convertToRecipeStepResponses(List<RecipeStep> recipeSteps) {
-        return recipeSteps.stream()
-                .map(RecipeStepResponse::new)
-                .toList();
     }
 
     private List<MainRecipeResponse> convertToMainRecipeResponses(List<RecipeDataResponse> recipeDataResponses) {
@@ -178,60 +133,11 @@ public class RecipeService {
                 .collect(Collectors.toList());
     }
 
-    private Pageable getPageable(int pageNumber, int pageSize) {
+    private Pageable getValidatedPageable(int pageNumber, int pageSize) {
         long offset = (long) pageNumber * pageSize;
         if (offset > Integer.MAX_VALUE) {
             throw new InvalidParameterException("적절하지 않은 페이지 정보입니다.");
         }
         return PageRequest.of(pageNumber, pageSize);
-    }
-
-    private Recipe getRecipeByRecipeId(long recipeId) {
-        return recipeRepository.findById(recipeId)
-                .orElseThrow(() -> new NotFoundException("해당되는 레시피가 없습니다."));
-    }
-
-    private void validateRecipeStepSequence(long recipeId, int sequence) {
-        int previousSequence = sequence - 1;
-        if (previousSequence >= 1) {
-            recipeStepRepository.findByRecipeIdAndSequence(recipeId, previousSequence)
-                    .orElseThrow(() -> new InvalidParameterException("이전 스텝이 등록되지 않았습니다."));
-        }
-    }
-
-    private RecipeStep saveRecipeStep(
-            Recipe recipe, String imageUrl,
-            RecipeStepRequest recipeStepRequest,
-            LocalTime cookingTime
-    ) {
-        RecipeStep recipeStep = new RecipeStep(
-                recipe,
-                imageUrl,
-                recipeStepRequest.description(),
-                recipeStepRequest.sequence(),
-                cookingTime
-        );
-
-        return recipeStepRepository.save(recipeStep);
-    }
-
-    private String getValidatedImageUrl(String image) {
-        if (image == null) {
-            return null;
-        }
-        if (image.isBlank()) {
-            throw new InvalidParameterException("적절하지 않은 이미지 이름입니다.");
-        }
-        return s3ClientService.getImageUrl(image).url();
-    }
-
-    private LocalTime getValidatedCookingTime(String cookingTime) {
-        try {
-            return Optional.ofNullable(cookingTime)
-                    .map(LocalTime::parse)
-                    .orElse(null);
-        } catch (DateTimeParseException exception) {
-            throw new InvalidParameterException("적절하지 않은 조리시간입니다.");
-        }
     }
 }

--- a/backend/src/main/java/net/pengcook/recipe/service/RecipeService.java
+++ b/backend/src/main/java/net/pengcook/recipe/service/RecipeService.java
@@ -93,7 +93,7 @@ public class RecipeService {
     public RecipeStepResponse createRecipeStep(long recipeId, RecipeStepRequest recipeStepRequest) {
         validateRecipeStepSequence(recipeId, recipeStepRequest.sequence());
         Recipe recipe = getRecipeByRecipeId(recipeId);
-        String imageUrl = s3ClientService.getImageUrl(recipeStepRequest.image()).url();
+        String imageUrl = getImageUrl(recipeStepRequest.image());
         String description = recipeStepRequest.description();
         LocalTime cookingTime = LocalTime.parse(recipeStepRequest.cookingTime());
 
@@ -209,5 +209,15 @@ public class RecipeService {
         );
 
         return recipeStepRepository.save(recipeStep);
+    }
+
+    private String getImageUrl(String image) {
+        if (image == null) {
+            return null;
+        }
+        if (image.isBlank()) {
+            throw new InvalidParameterException("적절하지 않은 이미지 이름입니다.");
+        }
+        return s3ClientService.getImageUrl(image).url();
     }
 }

--- a/backend/src/main/java/net/pengcook/recipe/service/RecipeService.java
+++ b/backend/src/main/java/net/pengcook/recipe/service/RecipeService.java
@@ -94,9 +94,9 @@ public class RecipeService {
     public RecipeStepResponse createRecipeStep(long recipeId, RecipeStepRequest recipeStepRequest) {
         validateRecipeStepSequence(recipeId, recipeStepRequest.sequence());
         Recipe recipe = getRecipeByRecipeId(recipeId);
-        String imageUrl = getImageUrl(recipeStepRequest.image());
+        String imageUrl = getValidatedImageUrl(recipeStepRequest.image());
         String description = recipeStepRequest.description();
-        LocalTime cookingTime = getCookingTime(recipeStepRequest.cookingTime());
+        LocalTime cookingTime = getValidatedCookingTime(recipeStepRequest.cookingTime());
 
         Optional<RecipeStep> existingRecipeStep = recipeStepRepository.findByRecipeIdAndSequence(
                 recipeId,
@@ -215,7 +215,7 @@ public class RecipeService {
         return recipeStepRepository.save(recipeStep);
     }
 
-    private String getImageUrl(String image) {
+    private String getValidatedImageUrl(String image) {
         if (image == null) {
             return null;
         }
@@ -225,7 +225,7 @@ public class RecipeService {
         return s3ClientService.getImageUrl(image).url();
     }
 
-    private LocalTime getCookingTime(String cookingTime) {
+    private LocalTime getValidatedCookingTime(String cookingTime) {
         try {
             return Optional.ofNullable(cookingTime)
                     .map(LocalTime::parse)

--- a/backend/src/main/java/net/pengcook/recipe/service/RecipeStepService.java
+++ b/backend/src/main/java/net/pengcook/recipe/service/RecipeStepService.java
@@ -1,0 +1,115 @@
+package net.pengcook.recipe.service;
+
+import java.time.LocalTime;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import net.pengcook.image.service.S3ClientService;
+import net.pengcook.recipe.domain.Recipe;
+import net.pengcook.recipe.domain.RecipeStep;
+import net.pengcook.recipe.dto.RecipeStepRequest;
+import net.pengcook.recipe.dto.RecipeStepResponse;
+import net.pengcook.recipe.exception.InvalidParameterException;
+import net.pengcook.recipe.exception.NotFoundException;
+import net.pengcook.recipe.repository.RecipeRepository;
+import net.pengcook.recipe.repository.RecipeStepRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class RecipeStepService {
+
+    private final RecipeStepRepository recipeStepRepository;
+    private final RecipeRepository recipeRepository;
+    private final S3ClientService s3ClientService;
+
+    public List<RecipeStepResponse> readRecipeSteps(long recipeId) {
+        List<RecipeStep> recipeSteps = recipeStepRepository.findAllByRecipeIdOrderBySequence(recipeId);
+        return convertToRecipeStepResponses(recipeSteps);
+    }
+
+    public RecipeStepResponse readRecipeStep(long recipeId, long sequence) {
+        RecipeStep recipeStep = recipeStepRepository.findByRecipeIdAndSequence(recipeId, sequence)
+                .orElseThrow(() -> new NotFoundException("해당되는 레시피 스텝 정보가 없습니다."));
+
+        return new RecipeStepResponse(recipeStep);
+    }
+
+    public RecipeStepResponse createRecipeStep(long recipeId, RecipeStepRequest recipeStepRequest) {
+        validateRecipeStepSequence(recipeId, recipeStepRequest.sequence());
+        Recipe recipe = getRecipeByRecipeId(recipeId);
+        String imageUrl = getValidatedImageUrl(recipeStepRequest.image());
+        String description = recipeStepRequest.description();
+        LocalTime cookingTime = getValidatedCookingTime(recipeStepRequest.cookingTime());
+
+        Optional<RecipeStep> existingRecipeStep = recipeStepRepository.findByRecipeIdAndSequence(
+                recipeId,
+                recipeStepRequest.sequence()
+        );
+
+        RecipeStep recipeStep = existingRecipeStep
+                .map(currentRecipeStep -> currentRecipeStep.update(imageUrl, description, cookingTime))
+                .orElseGet(() -> saveRecipeStep(recipe, imageUrl, recipeStepRequest, cookingTime));
+
+        return new RecipeStepResponse(recipeStep);
+    }
+
+    private List<RecipeStepResponse> convertToRecipeStepResponses(List<RecipeStep> recipeSteps) {
+        return recipeSteps.stream()
+                .map(RecipeStepResponse::new)
+                .toList();
+    }
+
+    private void validateRecipeStepSequence(long recipeId, int sequence) {
+        int previousSequence = sequence - 1;
+        if (previousSequence >= 1) {
+            recipeStepRepository.findByRecipeIdAndSequence(recipeId, previousSequence)
+                    .orElseThrow(() -> new InvalidParameterException("이전 스텝이 등록되지 않았습니다."));
+        }
+    }
+
+    private Recipe getRecipeByRecipeId(long recipeId) {
+        return recipeRepository.findById(recipeId)
+                .orElseThrow(() -> new NotFoundException("해당되는 레시피가 없습니다."));
+    }
+
+    private String getValidatedImageUrl(String image) {
+        if (image == null) {
+            return null;
+        }
+        if (image.isBlank()) {
+            throw new InvalidParameterException("적절하지 않은 이미지 이름입니다.");
+        }
+        return s3ClientService.getImageUrl(image).url();
+    }
+
+    private LocalTime getValidatedCookingTime(String cookingTime) {
+        try {
+            return Optional.ofNullable(cookingTime)
+                    .map(LocalTime::parse)
+                    .orElse(null);
+        } catch (DateTimeParseException exception) {
+            throw new InvalidParameterException("적절하지 않은 조리시간입니다.");
+        }
+    }
+
+    private RecipeStep saveRecipeStep(
+            Recipe recipe,
+            String imageUrl,
+            RecipeStepRequest recipeStepRequest,
+            LocalTime cookingTime
+    ) {
+        RecipeStep recipeStep = new RecipeStep(
+                recipe,
+                imageUrl,
+                recipeStepRequest.description(),
+                recipeStepRequest.sequence(),
+                cookingTime
+        );
+
+        return recipeStepRepository.save(recipeStep);
+    }
+}

--- a/backend/src/test/java/net/pengcook/recipe/service/RecipeServiceTest.java
+++ b/backend/src/test/java/net/pengcook/recipe/service/RecipeServiceTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.jdbc.Sql;
@@ -122,6 +123,30 @@ class RecipeServiceTest {
                 () -> assertThat(recipeStepResponse.recipeId()).isEqualTo(2L),
                 () -> assertThat(recipeStepResponse.description()).isEqualTo("새로운 스텝 설명")
         );
+    }
+
+    @Test
+    @DisplayName("레시피 스텝 생성 요청 이미지 값이 null이어도 정상적으로 생성하고, 이미지에 null을 저장한다.")
+    void createRecipeStepWithNullImage() {
+        RecipeStepRequest recipeStepRequest = new RecipeStepRequest(null, "새로운 스텝 설명", 1, "00:05:00");
+
+        RecipeStepResponse recipeStepResponse = recipeService.createRecipeStep(2L, recipeStepRequest);
+
+        assertAll(
+                () -> assertThat(recipeStepResponse.recipeId()).isEqualTo(2L),
+                () -> assertThat(recipeStepResponse.image()).isNull(),
+                () -> assertThat(recipeStepResponse.description()).isEqualTo("새로운 스텝 설명")
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " ", "    "})
+    @DisplayName("레시피 스텝 생성 요청 이미지 값이 빈 문자열이거나 공백만 있을 경우 예외가 발생한다.")
+    void createRecipeStepWhenBlankImage(String image) {
+        RecipeStepRequest recipeStepRequest = new RecipeStepRequest(image, "새로운 스텝 설명", 1, "00:05:00");
+
+        assertThatThrownBy(() -> recipeService.createRecipeStep(2L, recipeStepRequest))
+                .isInstanceOf(InvalidParameterException.class);
     }
 
     @Test

--- a/backend/src/test/java/net/pengcook/recipe/service/RecipeServiceTest.java
+++ b/backend/src/test/java/net/pengcook/recipe/service/RecipeServiceTest.java
@@ -4,8 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import java.time.LocalTime;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 import net.pengcook.authentication.domain.UserInfo;
@@ -17,8 +15,6 @@ import net.pengcook.recipe.dto.PageRecipeRequest;
 import net.pengcook.recipe.dto.RecipeOfUserRequest;
 import net.pengcook.recipe.dto.RecipeRequest;
 import net.pengcook.recipe.dto.RecipeResponse;
-import net.pengcook.recipe.dto.RecipeStepRequest;
-import net.pengcook.recipe.dto.RecipeStepResponse;
 import net.pengcook.recipe.exception.InvalidParameterException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -26,7 +22,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.jdbc.Sql;
@@ -37,6 +32,14 @@ class RecipeServiceTest {
 
     @Autowired
     private RecipeService recipeService;
+
+    static Stream<Arguments> provideParameters() {
+        return Stream.of(
+                Arguments.of(0, 2, List.of(2L, 3L)),
+                Arguments.of(1, 2, List.of(7L, 9L)),
+                Arguments.of(1, 3, List.of(9L, 14L, 15L))
+        );
+    }
 
     @ParameterizedTest
     @CsvSource(value = {"0,2,15", "1,2,13", "1,3,12"})
@@ -85,121 +88,6 @@ class RecipeServiceTest {
         assertThat(recipe.recipeId()).isEqualTo(16L);
     }
 
-    @Test
-    @DisplayName("특정 레시피의 스텝을 sequence 순서로 조회한다.")
-    void readRecipeSteps() {
-        long recipeId = 1L;
-        List<RecipeStepResponse> expectedRecipeStepResponses = Arrays.asList(
-                new RecipeStepResponse(1L, 1, "레시피1 설명1 이미지", "레시피1 설명1", 1, LocalTime.parse("00:10:00")),
-                new RecipeStepResponse(3L, 1, "레시피1 설명2 이미지", "레시피1 설명2", 2, LocalTime.parse("00:20:00")),
-                new RecipeStepResponse(2L, 1, "레시피1 설명3 이미지", "레시피1 설명3", 3, LocalTime.parse("00:30:00"))
-        );
-
-        List<RecipeStepResponse> recipeStepResponses = recipeService.readRecipeSteps(recipeId);
-
-        assertThat(recipeStepResponses).isEqualTo(expectedRecipeStepResponses);
-    }
-
-    @Test
-    @DisplayName("특정 레시피의 특정 레시피 스텝을 조회한다.")
-    void readRecipeStep() {
-        RecipeStepResponse recipeStepResponse = recipeService.readRecipeStep(1L, 1L);
-
-        assertAll(
-                () -> assertThat(recipeStepResponse.recipeId()).isEqualTo(1L),
-                () -> assertThat(recipeStepResponse.description()).isEqualTo("레시피1 설명1")
-        );
-
-    }
-
-    @Test
-    @DisplayName("특정 레시피의 레시피 스텝을 생성한다.")
-    void createRecipeStep() {
-        RecipeStepRequest recipeStepRequest = new RecipeStepRequest("새로운 스텝 이미지.jpg", "새로운 스텝 설명", 1, "00:05:00");
-
-        RecipeStepResponse recipeStepResponse = recipeService.createRecipeStep(2L, recipeStepRequest);
-
-        assertAll(
-                () -> assertThat(recipeStepResponse.recipeId()).isEqualTo(2L),
-                () -> assertThat(recipeStepResponse.description()).isEqualTo("새로운 스텝 설명")
-        );
-    }
-
-    @Test
-    @DisplayName("레시피 스텝 생성 요청 이미지 값이 null이어도 정상적으로 생성하고, 이미지에 null을 저장한다.")
-    void createRecipeStepWithNullImage() {
-        RecipeStepRequest recipeStepRequest = new RecipeStepRequest(null, "새로운 스텝 설명", 1, "00:05:00");
-
-        RecipeStepResponse recipeStepResponse = recipeService.createRecipeStep(2L, recipeStepRequest);
-
-        assertAll(
-                () -> assertThat(recipeStepResponse.recipeId()).isEqualTo(2L),
-                () -> assertThat(recipeStepResponse.image()).isNull(),
-                () -> assertThat(recipeStepResponse.description()).isEqualTo("새로운 스텝 설명")
-        );
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {"", " ", "    "})
-    @DisplayName("레시피 스텝 생성 요청 이미지 값이 빈 문자열이거나 공백만 있을 경우 예외가 발생한다.")
-    void createRecipeStepWhenBlankImage(String image) {
-        RecipeStepRequest recipeStepRequest = new RecipeStepRequest(image, "새로운 스텝 설명", 1, "00:05:00");
-
-        assertThatThrownBy(() -> recipeService.createRecipeStep(2L, recipeStepRequest))
-                .isInstanceOf(InvalidParameterException.class);
-    }
-
-    @Test
-    @DisplayName("레시피 스텝 생성 요청 조리시간 값이 null이어도 정상적으로 생성하고, 조리시간에 null을 저장한다.")
-    void createRecipeStepWithNullCookingTime() {
-        RecipeStepRequest recipeStepRequest = new RecipeStepRequest("image.jpg", "스텝 설명", 1, null);
-
-        RecipeStepResponse recipeStepResponse = recipeService.createRecipeStep(2L, recipeStepRequest);
-
-        assertAll(
-                () -> assertThat(recipeStepResponse.recipeId()).isEqualTo(2L),
-                () -> assertThat(recipeStepResponse.cookingTime()).isNull()
-        );
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {"", " ", "aa:bb", "test"})
-    @DisplayName("레시피 스텝 생성 요청 조리시간의 형태가 HH:mm:ss가 아닌 경우 예외가 발생한다.")
-    void createRecipeStepWhenInappropriateCookingTime(String cookingTime) {
-        RecipeStepRequest recipeStepRequest = new RecipeStepRequest("image.jpg", "새로운 스텝 설명", 1, cookingTime);
-
-        assertThatThrownBy(() -> recipeService.createRecipeStep(2L, recipeStepRequest))
-                .isInstanceOf(InvalidParameterException.class);
-    }
-
-    @Test
-    @DisplayName("레시피 스텝 등록 시 이미 존재하는 정보가 있으면 새로운 내용으로 수정한다.")
-    void createRecipeStepWithExistingRecipeStep() {
-        RecipeStepRequest recipeStepRequest = new RecipeStepRequest(
-                "changedImage.jpg",
-                "changedDescription",
-                1,
-                "00:05:00"
-        );
-
-        RecipeStepResponse recipeStepResponse = recipeService.createRecipeStep(1L, recipeStepRequest);
-
-        assertAll(
-                () -> assertThat(recipeStepResponse.id()).isEqualTo(1L),
-                () -> assertThat(recipeStepResponse.description()).isEqualTo("changedDescription"),
-                () -> assertThat(recipeStepResponse.image()).endsWith("changedImage.jpg")
-        );
-    }
-
-    @Test
-    @DisplayName("레시피 스텝 등록 시 이전 sequence 정보가 없으면 예외가 발생한다.")
-    void createRecipeWhenPreviousSequenceDoesNotExist() {
-        RecipeStepRequest recipeStepRequest = new RecipeStepRequest("새로운 스텝 이미지.jpg", "새로운 스텝 설명", 2, "00:05:00");
-
-        assertThatThrownBy(() -> recipeService.createRecipeStep(2L, recipeStepRequest))
-                .isInstanceOf(InvalidParameterException.class);
-    }
-
     @ParameterizedTest
     @MethodSource("provideParameters")
     @DisplayName("특정 카테고리의 레시피를 찾는다.")
@@ -215,21 +103,13 @@ class RecipeServiceTest {
         );
     }
 
-    static Stream<Arguments> provideParameters() {
-        return Stream.of(
-                Arguments.of(0, 2, List.of(2L, 3L)),
-                Arguments.of(1, 2, List.of(7L, 9L)),
-                Arguments.of(1, 3, List.of(9L, 14L, 15L))
-        );
-    }
-
     @Test
     @DisplayName("특정 사용자의 레시피를 찾는다.")
     void readRecipesOfUser() {
         RecipeOfUserRequest request = new RecipeOfUserRequest(1L, 0, 3);
         List<Long> expected = List.of(15L, 14L, 13L);
         int pageSize = 3;
-        
+
         List<MainRecipeResponse> mainRecipeResponses = recipeService.readRecipesOfUser(request);
         List<Long> actual = mainRecipeResponses.stream().map(MainRecipeResponse::recipeId).toList();
 
@@ -238,5 +118,4 @@ class RecipeServiceTest {
                 () -> assertThat(actual).containsAll(expected)
         );
     }
-
 }

--- a/backend/src/test/java/net/pengcook/recipe/service/RecipeServiceTest.java
+++ b/backend/src/test/java/net/pengcook/recipe/service/RecipeServiceTest.java
@@ -150,6 +150,29 @@ class RecipeServiceTest {
     }
 
     @Test
+    @DisplayName("레시피 스텝 생성 요청 조리시간 값이 null이어도 정상적으로 생성하고, 조리시간에 null을 저장한다.")
+    void createRecipeStepWithNullCookingTime() {
+        RecipeStepRequest recipeStepRequest = new RecipeStepRequest("image.jpg", "스텝 설명", 1, null);
+
+        RecipeStepResponse recipeStepResponse = recipeService.createRecipeStep(2L, recipeStepRequest);
+
+        assertAll(
+                () -> assertThat(recipeStepResponse.recipeId()).isEqualTo(2L),
+                () -> assertThat(recipeStepResponse.cookingTime()).isNull()
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " ", "aa:bb", "test"})
+    @DisplayName("레시피 스텝 생성 요청 조리시간의 형태가 HH:mm:ss가 아닌 경우 예외가 발생한다.")
+    void createRecipeStepWhenInappropriateCookingTime(String cookingTime) {
+        RecipeStepRequest recipeStepRequest = new RecipeStepRequest("image.jpg", "새로운 스텝 설명", 1, cookingTime);
+
+        assertThatThrownBy(() -> recipeService.createRecipeStep(2L, recipeStepRequest))
+                .isInstanceOf(InvalidParameterException.class);
+    }
+
+    @Test
     @DisplayName("레시피 스텝 등록 시 이미 존재하는 정보가 있으면 새로운 내용으로 수정한다.")
     void createRecipeStepWithExistingRecipeStep() {
         RecipeStepRequest recipeStepRequest = new RecipeStepRequest(

--- a/backend/src/test/java/net/pengcook/recipe/service/RecipeStepServiceTest.java
+++ b/backend/src/test/java/net/pengcook/recipe/service/RecipeStepServiceTest.java
@@ -1,0 +1,142 @@
+package net.pengcook.recipe.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.List;
+import net.pengcook.recipe.dto.RecipeStepRequest;
+import net.pengcook.recipe.dto.RecipeStepResponse;
+import net.pengcook.recipe.exception.InvalidParameterException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Sql(value = "/data/recipe.sql")
+class RecipeStepServiceTest {
+
+    @Autowired
+    private RecipeStepService recipeStepService;
+
+    @Test
+    @DisplayName("특정 레시피의 스텝을 sequence 순서로 조회한다.")
+    void readRecipeSteps() {
+        long recipeId = 1L;
+        List<RecipeStepResponse> expectedRecipeStepResponses = Arrays.asList(
+                new RecipeStepResponse(1L, 1, "레시피1 설명1 이미지", "레시피1 설명1", 1, LocalTime.parse("00:10:00")),
+                new RecipeStepResponse(3L, 1, "레시피1 설명2 이미지", "레시피1 설명2", 2, LocalTime.parse("00:20:00")),
+                new RecipeStepResponse(2L, 1, "레시피1 설명3 이미지", "레시피1 설명3", 3, LocalTime.parse("00:30:00"))
+        );
+
+        List<RecipeStepResponse> recipeStepResponses = recipeStepService.readRecipeSteps(recipeId);
+
+        assertThat(recipeStepResponses).isEqualTo(expectedRecipeStepResponses);
+    }
+
+    @Test
+    @DisplayName("특정 레시피의 특정 레시피 스텝을 조회한다.")
+    void readRecipeStep() {
+        RecipeStepResponse recipeStepResponse = recipeStepService.readRecipeStep(1L, 1L);
+
+        assertAll(
+                () -> assertThat(recipeStepResponse.recipeId()).isEqualTo(1L),
+                () -> assertThat(recipeStepResponse.description()).isEqualTo("레시피1 설명1")
+        );
+
+    }
+
+    @Test
+    @DisplayName("특정 레시피의 레시피 스텝을 생성한다.")
+    void createRecipeStep() {
+        RecipeStepRequest recipeStepRequest = new RecipeStepRequest("새로운 스텝 이미지.jpg", "새로운 스텝 설명", 1, "00:05:00");
+
+        RecipeStepResponse recipeStepResponse = recipeStepService.createRecipeStep(2L, recipeStepRequest);
+
+        assertAll(
+                () -> assertThat(recipeStepResponse.recipeId()).isEqualTo(2L),
+                () -> assertThat(recipeStepResponse.description()).isEqualTo("새로운 스텝 설명")
+        );
+    }
+
+    @Test
+    @DisplayName("레시피 스텝 생성 요청 이미지 값이 null이어도 정상적으로 생성하고, 이미지에 null을 저장한다.")
+    void createRecipeStepWithNullImage() {
+        RecipeStepRequest recipeStepRequest = new RecipeStepRequest(null, "새로운 스텝 설명", 1, "00:05:00");
+
+        RecipeStepResponse recipeStepResponse = recipeStepService.createRecipeStep(2L, recipeStepRequest);
+
+        assertAll(
+                () -> assertThat(recipeStepResponse.recipeId()).isEqualTo(2L),
+                () -> assertThat(recipeStepResponse.image()).isNull(),
+                () -> assertThat(recipeStepResponse.description()).isEqualTo("새로운 스텝 설명")
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " ", "    "})
+    @DisplayName("레시피 스텝 생성 요청 이미지 값이 빈 문자열이거나 공백만 있을 경우 예외가 발생한다.")
+    void createRecipeStepWhenBlankImage(String image) {
+        RecipeStepRequest recipeStepRequest = new RecipeStepRequest(image, "새로운 스텝 설명", 1, "00:05:00");
+
+        assertThatThrownBy(() -> recipeStepService.createRecipeStep(2L, recipeStepRequest))
+                .isInstanceOf(InvalidParameterException.class);
+    }
+
+    @Test
+    @DisplayName("레시피 스텝 생성 요청 조리시간 값이 null이어도 정상적으로 생성하고, 조리시간에 null을 저장한다.")
+    void createRecipeStepWithNullCookingTime() {
+        RecipeStepRequest recipeStepRequest = new RecipeStepRequest("image.jpg", "스텝 설명", 1, null);
+
+        RecipeStepResponse recipeStepResponse = recipeStepService.createRecipeStep(2L, recipeStepRequest);
+
+        assertAll(
+                () -> assertThat(recipeStepResponse.recipeId()).isEqualTo(2L),
+                () -> assertThat(recipeStepResponse.cookingTime()).isNull()
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " ", "aa:bb", "test"})
+    @DisplayName("레시피 스텝 생성 요청 조리시간의 형태가 HH:mm:ss가 아닌 경우 예외가 발생한다.")
+    void createRecipeStepWhenInappropriateCookingTime(String cookingTime) {
+        RecipeStepRequest recipeStepRequest = new RecipeStepRequest("image.jpg", "새로운 스텝 설명", 1, cookingTime);
+
+        assertThatThrownBy(() -> recipeStepService.createRecipeStep(2L, recipeStepRequest))
+                .isInstanceOf(InvalidParameterException.class);
+    }
+
+    @Test
+    @DisplayName("레시피 스텝 등록 시 이미 존재하는 정보가 있으면 새로운 내용으로 수정한다.")
+    void createRecipeStepWithExistingRecipeStep() {
+        RecipeStepRequest recipeStepRequest = new RecipeStepRequest(
+                "changedImage.jpg",
+                "changedDescription",
+                1,
+                "00:05:00"
+        );
+
+        RecipeStepResponse recipeStepResponse = recipeStepService.createRecipeStep(1L, recipeStepRequest);
+
+        assertAll(
+                () -> assertThat(recipeStepResponse.id()).isEqualTo(1L),
+                () -> assertThat(recipeStepResponse.description()).isEqualTo("changedDescription"),
+                () -> assertThat(recipeStepResponse.image()).endsWith("changedImage.jpg")
+        );
+    }
+
+    @Test
+    @DisplayName("레시피 스텝 등록 시 이전 sequence 정보가 없으면 예외가 발생한다.")
+    void createRecipeWhenPreviousSequenceDoesNotExist() {
+        RecipeStepRequest recipeStepRequest = new RecipeStepRequest("새로운 스텝 이미지.jpg", "새로운 스텝 설명", 2, "00:05:00");
+
+        assertThatThrownBy(() -> recipeStepService.createRecipeStep(2L, recipeStepRequest))
+                .isInstanceOf(InvalidParameterException.class);
+    }
+}


### PR DESCRIPTION
레시피 스텝 생성 시 검증 로직 수정하였습니다. 

- 이미지 관련
(기존) 이미지에 null 값 혹은 빈 문자열을 보내면 null, " "로 저장 → (변경) 이미지를 null로 보내면 `null로 저장`, 빈 문자열 입력 불가

- 조리시간 관련
(기존) 조리시간에 null값 불가, 올바르지 않은 형태의 조리시간 보내면 500에러 발생 -> (변경) 조리시간 `null 가능`, 형태 검증 추가