### PR TITLE
:technologist: add issue automation

### DIFF
--- a/.github/issue-branch.yaml
+++ b/.github/issue-branch.yaml
@@ -1,0 +1,17 @@
+mode: immediate
+branchName: ${issue.number}
+branches:
+  - label: BE
+    name: be/dev
+    prefix: be/feat/
+  - label: AN
+    name: an/dev
+    prefix: an/feat/
+autoLinkIssue: true
+autoCloseIssue: true
+openPR: true
+copyIssueDescriptionToPR: true
+copyIssueLabelsToPR: true
+copyIssueAssigneeToPR: true
+copyIssueProjectsToPR: true
+copyIssueMilestoneToPR: true

--- a/.github/workflows/issue-automation.yaml
+++ b/.github/workflows/issue-automation.yaml
@@ -1,0 +1,16 @@
+name: Issue Automation
+
+on:
+  issues:
+    types: [ opened ]
+  pull_request:
+    types: [ opened, closed ]
+
+jobs:
+  create-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create new Branch
+        uses: robvanderleek/create-issue-branch@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### 📌 이 `PR` 은 `main` 브랜치로 향합니다.
`issue automation` 은 `Default Branch` 에 스크립트가 있어야 동작합니다.

### 이슈 생성 시 브랜치 자동 생성
이제 이슈를 생성하면 해당 이슈 번호와 `Labels` 를 통해 `be/feat/213` 또는 `an/feat/214` 브랜치가 자동 생성 됩니다!
![image](https://github.com/user-attachments/assets/209a1a50-cd02-488b-8374-5bedf922e752)

### 이슈 생성 시 `Pull Request` 자동 생성
똑같이 PR 이 자동으로 생성되고 각 분야 별로 `be/dev <- be/feat/213` 또는 `an/dev <- an/feat/214` 를 향하도록 PR이 생성됩니다.
![image](https://github.com/user-attachments/assets/fe359c98-872d-43fe-ba3f-c99e44f4e6a6)

### `PR Merge` 시
- `Branch` 는 자동으로 삭제 됩니다.
- ⚠️ 하지만 `Issue` 가 자동으로 닫히진 않더군요. 우선 이슈는 직접 `Close` 해주시길 바랍니다! 추후 자동화 가능 할 수도 있습니다.
