### PR TITLE
✨ search recipes with keywords

### DIFF
--- a/backend/src/main/java/net/pengcook/recipe/dto/PageRecipeRequest.java
+++ b/backend/src/main/java/net/pengcook/recipe/dto/PageRecipeRequest.java
@@ -7,6 +7,7 @@ public record PageRecipeRequest(
         @Min(0) int pageNumber,
         @Min(1) int pageSize,
         @Nullable String category,
-        @Nullable String keyword
+        @Nullable String keyword,
+        @Nullable Long userId
 ) {
 }

--- a/backend/src/main/java/net/pengcook/recipe/dto/PageRecipeRequest.java
+++ b/backend/src/main/java/net/pengcook/recipe/dto/PageRecipeRequest.java
@@ -2,15 +2,11 @@ package net.pengcook.recipe.dto;
 
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
 
 public record PageRecipeRequest(
-        @Nullable @NotBlank String category,
-        @Nullable @NotBlank String keyword,
         @Min(0) int pageNumber,
-        @Min(1) int pageSize
+        @Min(1) int pageSize,
+        @Nullable String category,
+        @Nullable String keyword
 ) {
-    public PageRecipeRequest(@Min(0) int pageNumber, @Min(1) int pageSize) {
-        this(null, null, pageNumber, pageSize);
-    }
 }

--- a/backend/src/main/java/net/pengcook/recipe/dto/PageRecipeRequest.java
+++ b/backend/src/main/java/net/pengcook/recipe/dto/PageRecipeRequest.java
@@ -2,10 +2,11 @@ package net.pengcook.recipe.dto;
 
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 
 public record PageRecipeRequest(
-        @Nullable String category,
-        @Nullable String keyword,
+        @Nullable @NotBlank String category,
+        @Nullable @NotBlank String keyword,
         @Min(0) int pageNumber,
         @Min(1) int pageSize
 ) {

--- a/backend/src/main/java/net/pengcook/recipe/dto/PageRecipeRequest.java
+++ b/backend/src/main/java/net/pengcook/recipe/dto/PageRecipeRequest.java
@@ -1,6 +1,15 @@
 package net.pengcook.recipe.dto;
 
+import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.Min;
 
-public record PageRecipeRequest(@Min(0) int pageNumber, @Min(1) int pageSize) {
+public record PageRecipeRequest(
+        @Nullable String category,
+        @Nullable String keyword,
+        @Min(0) int pageNumber,
+        @Min(1) int pageSize
+) {
+    public PageRecipeRequest(@Min(0) int pageNumber, @Min(1) int pageSize) {
+        this(null, null, pageNumber, pageSize);
+    }
 }

--- a/backend/src/main/java/net/pengcook/recipe/repository/RecipeRepository.java
+++ b/backend/src/main/java/net/pengcook/recipe/repository/RecipeRepository.java
@@ -18,12 +18,14 @@ public interface RecipeRepository extends JpaRepository<Recipe, Long> {
             LEFT JOIN Category c ON cr.category = c
             WHERE (:category IS NULL OR c.name = :category)
             AND (:keyword IS NULL OR CONCAT(r.title, r.description) LIKE CONCAT('%', :keyword, '%'))
+            AND (:userId IS NULL OR r.author.id = :userId)
             ORDER BY r.id DESC
             """)
     List<Long> findRecipeIdsByCategoryAndKeyword(
+            Pageable pageable,
             @Param("category") @Nullable String category,
             @Param("keyword") @Nullable String keyword,
-            Pageable pageable
+            @Param("userId") @Nullable Long userId
     );
 
     @Query("""

--- a/backend/src/main/java/net/pengcook/recipe/repository/RecipeRepository.java
+++ b/backend/src/main/java/net/pengcook/recipe/repository/RecipeRepository.java
@@ -1,20 +1,30 @@
 package net.pengcook.recipe.repository;
 
+import jakarta.annotation.Nullable;
 import java.util.List;
 import net.pengcook.recipe.domain.Recipe;
 import net.pengcook.recipe.dto.RecipeDataResponse;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RecipeRepository extends JpaRepository<Recipe, Long> {
 
     @Query("""
             SELECT r.id
             FROM Recipe r
+            JOIN FETCH CategoryRecipe cr ON cr.recipe = r
+            JOIN FETCH Category c ON cr.category = c
+            WHERE (:category IS NULL OR c.name = :category)
+            AND (:keyword IS NULL OR CONCAT(r.title, r.description) LIKE CONCAT('%', :keyword, '%'))
             ORDER BY r.id DESC
             """)
-    List<Long> findRecipeIds(Pageable pageable);
+    List<Long> findRecipeIdsByCategoryAndKeyword(
+            @Param("category") @Nullable String category,
+            @Param("keyword") @Nullable String keyword,
+            Pageable pageable
+    );
 
     @Query("""
             SELECT new net.pengcook.recipe.dto.RecipeDataResponse(

--- a/backend/src/main/java/net/pengcook/recipe/repository/RecipeRepository.java
+++ b/backend/src/main/java/net/pengcook/recipe/repository/RecipeRepository.java
@@ -12,10 +12,10 @@ import org.springframework.data.repository.query.Param;
 public interface RecipeRepository extends JpaRepository<Recipe, Long> {
 
     @Query("""
-            SELECT r.id
+            SELECT DISTINCT r.id
             FROM Recipe r
-            JOIN FETCH CategoryRecipe cr ON cr.recipe = r
-            JOIN FETCH Category c ON cr.category = c
+            LEFT JOIN CategoryRecipe cr ON cr.recipe = r
+            LEFT JOIN Category c ON cr.category = c
             WHERE (:category IS NULL OR c.name = :category)
             AND (:keyword IS NULL OR CONCAT(r.title, r.description) LIKE CONCAT('%', :keyword, '%'))
             ORDER BY r.id DESC

--- a/backend/src/main/java/net/pengcook/recipe/service/RecipeService.java
+++ b/backend/src/main/java/net/pengcook/recipe/service/RecipeService.java
@@ -47,9 +47,10 @@ public class RecipeService {
     public List<MainRecipeResponse> readRecipes(PageRecipeRequest pageRecipeRequest) {
         Pageable pageable = getValidatedPageable(pageRecipeRequest.pageNumber(), pageRecipeRequest.pageSize());
         List<Long> recipeIds = recipeRepository.findRecipeIdsByCategoryAndKeyword(
+                pageable,
                 pageRecipeRequest.category(),
                 pageRecipeRequest.keyword(),
-                pageable
+                pageRecipeRequest.userId()
         );
 
         List<RecipeDataResponse> recipeDataResponses = recipeRepository.findRecipeData(recipeIds);

--- a/backend/src/main/java/net/pengcook/recipe/service/RecipeService.java
+++ b/backend/src/main/java/net/pengcook/recipe/service/RecipeService.java
@@ -46,7 +46,11 @@ public class RecipeService {
 
     public List<MainRecipeResponse> readRecipes(PageRecipeRequest pageRecipeRequest) {
         Pageable pageable = getValidatedPageable(pageRecipeRequest.pageNumber(), pageRecipeRequest.pageSize());
-        List<Long> recipeIds = recipeRepository.findRecipeIds(pageable);
+        List<Long> recipeIds = recipeRepository.findRecipeIdsByCategoryAndKeyword(
+                pageRecipeRequest.category(),
+                pageRecipeRequest.keyword(),
+                pageable
+        );
 
         List<RecipeDataResponse> recipeDataResponses = recipeRepository.findRecipeData(recipeIds);
         return convertToMainRecipeResponses(recipeDataResponses);

--- a/backend/src/test/java/net/pengcook/category/repository/CategoryRecipeRepositoryTest.java
+++ b/backend/src/test/java/net/pengcook/category/repository/CategoryRecipeRepositoryTest.java
@@ -20,7 +20,7 @@ class CategoryRecipeRepositoryTest {
 
     @Test
     @DisplayName("요청한 카테고리와 페이지에 해당하는 레시피 id 목록을 반환한다.")
-    void findRecipeIds() {
+    void findRecipeIdsByCategoryAndKeyword() {
         Pageable pageable = PageRequest.of(0, 3);
 
         List<Long> recipeIds = repository.findRecipeIdsByCategoryName("한식", pageable);

--- a/backend/src/test/java/net/pengcook/recipe/controller/RecipeControllerTest.java
+++ b/backend/src/test/java/net/pengcook/recipe/controller/RecipeControllerTest.java
@@ -42,10 +42,11 @@ class RecipeControllerTest extends RestDocsSetting {
                         "특정 페이지의 레시피 목록을 조회합니다.",
                         "레시피 조회 API",
                         queryParameters(
+                                parameterWithName("pageNumber").description("페이지 번호"),
+                                parameterWithName("pageSize").description("페이지 크기"),
                                 parameterWithName("category").description("조회 카테고리").optional(),
                                 parameterWithName("keyword").description("제목 또는 설명 검색 키워드").optional(),
-                                parameterWithName("pageNumber").description("페이지 번호"),
-                                parameterWithName("pageSize").description("페이지 크기")
+                                parameterWithName("userId").description("작성자 아이디").optional()
                         ),
                         responseFields(
                                 fieldWithPath("[]").description("레시피 목록"),

--- a/backend/src/test/java/net/pengcook/recipe/controller/RecipeControllerTest.java
+++ b/backend/src/test/java/net/pengcook/recipe/controller/RecipeControllerTest.java
@@ -42,6 +42,8 @@ class RecipeControllerTest extends RestDocsSetting {
                         "특정 페이지의 레시피 목록을 조회합니다.",
                         "레시피 조회 API",
                         queryParameters(
+                                parameterWithName("category").description("조회 카테고리").optional(),
+                                parameterWithName("keyword").description("제목 또는 설명 검색 키워드").optional(),
                                 parameterWithName("pageNumber").description("페이지 번호"),
                                 parameterWithName("pageSize").description("페이지 크기")
                         ),

--- a/backend/src/test/java/net/pengcook/recipe/controller/RecipeControllerTest.java
+++ b/backend/src/test/java/net/pengcook/recipe/controller/RecipeControllerTest.java
@@ -379,85 +379,45 @@ class RecipeControllerTest extends RestDocsSetting {
     @DisplayName("카테고리별 레시피 개요 목록을 조회한다.")
     void readRecipesOfCategory() {
         RestAssured.given(spec).log().all()
-                .filter(document(DEFAULT_RESTDOCS_PATH,
-                        "특정 카테고리 페이지의 레시피 목록을 조회합니다.",
-                        "카테고리별 레시피 조회 API",
-                        queryParameters(
-                                parameterWithName("category").description("카테고리"),
-                                parameterWithName("pageNumber").description("페이지 번호"),
-                                parameterWithName("pageSize").description("페이지 크기")
-                        ),
-                        responseFields(
-                                fieldWithPath("[]").description("레시피 목록"),
-                                fieldWithPath("[].recipeId").description("레시피 아이디"),
-                                fieldWithPath("[].title").description("레시피 제목"),
-                                fieldWithPath("[].author").description("작성자 정보"),
-                                fieldWithPath("[].author.authorId").description("작성자 아이디"),
-                                fieldWithPath("[].author.authorName").description("작성자 이름"),
-                                fieldWithPath("[].author.authorImage").description("작성자 이미지"),
-                                fieldWithPath("[].cookingTime").description("조리 시간"),
-                                fieldWithPath("[].thumbnail").description("썸네일 이미지"),
-                                fieldWithPath("[].difficulty").description("난이도"),
-                                fieldWithPath("[].likeCount").description("좋아요 수"),
-                                fieldWithPath("[].commentCount").description("댓글 수"),
-                                fieldWithPath("[].description").description("레시피 설명"),
-                                fieldWithPath("[].createdAt").description("레시피 생성일시"),
-                                fieldWithPath("[].category").description("카테고리 목록"),
-                                fieldWithPath("[].category[].categoryId").description("카테고리 아이디"),
-                                fieldWithPath("[].category[].categoryName").description("카테고리 이름"),
-                                fieldWithPath("[].ingredient").description("재료 목록"),
-                                fieldWithPath("[].ingredient[].ingredientId").description("재료 아이디"),
-                                fieldWithPath("[].ingredient[].ingredientName").description("재료 이름"),
-                                fieldWithPath("[].ingredient[].requirement").description("재료 필수 여부")
-                        )))
-                .queryParam("category", "한식")
+                .filter(document(DEFAULT_RESTDOCS_PATH))
                 .queryParam("pageNumber", 0)
                 .queryParam("pageSize", 3)
-                .when().get("/recipes/search")
+                .queryParam("category", "한식")
+                .when().get("/recipes")
                 .then().log().all()
-                .body("size()", is(3));
+                .body("size()", is(3))
+                .body("[0].category[1].categoryName", is("한식"))
+                .body("[1].category[0].categoryName", is("한식"));
+    }
+
+    @Test
+    @DisplayName("키워드로 레시피 개요 목록을 조회한다.")
+    void readRecipesOfKeyword() {
+        RestAssured.given(spec).log().all()
+                .filter(document(DEFAULT_RESTDOCS_PATH))
+                .queryParam("pageNumber", 0)
+                .queryParam("pageSize", 3)
+                .queryParam("keyword", "찌개")
+                .when().get("/recipes")
+                .then().log().all()
+                .body("size()", is(2))
+                .body("[0].title", is("된장찌개"))
+                .body("[1].title", is("김치찌개"));
     }
 
     @Test
     @DisplayName("사용자별 레시피 개요 목록을 조회한다.")
     void readRecipesOfUser() {
         RestAssured.given(spec).log().all()
-                .filter(document(DEFAULT_RESTDOCS_PATH,
-                        "특정 사용자가 작성한 레시피 목록을 조회합니다.",
-                        "사용자별 레시피 조회 API",
-                        queryParameters(
-                                parameterWithName("userId").description("사용자 아이디"),
-                                parameterWithName("pageNumber").description("페이지 번호"),
-                                parameterWithName("pageSize").description("페이지 크기")
-                        ),
-                        responseFields(
-                                fieldWithPath("[]").description("레시피 목록"),
-                                fieldWithPath("[].recipeId").description("레시피 아이디"),
-                                fieldWithPath("[].title").description("레시피 제목"),
-                                fieldWithPath("[].author").description("작성자 정보"),
-                                fieldWithPath("[].author.authorId").description("작성자 아이디"),
-                                fieldWithPath("[].author.authorName").description("작성자 이름"),
-                                fieldWithPath("[].author.authorImage").description("작성자 이미지"),
-                                fieldWithPath("[].cookingTime").description("조리 시간"),
-                                fieldWithPath("[].thumbnail").description("썸네일 이미지"),
-                                fieldWithPath("[].difficulty").description("난이도"),
-                                fieldWithPath("[].likeCount").description("좋아요 수"),
-                                fieldWithPath("[].commentCount").description("댓글 수"),
-                                fieldWithPath("[].description").description("레시피 설명"),
-                                fieldWithPath("[].createdAt").description("레시피 생성일시"),
-                                fieldWithPath("[].category").description("카테고리 목록"),
-                                fieldWithPath("[].category[].categoryId").description("카테고리 아이디"),
-                                fieldWithPath("[].category[].categoryName").description("카테고리 이름"),
-                                fieldWithPath("[].ingredient").description("재료 목록"),
-                                fieldWithPath("[].ingredient[].ingredientId").description("재료 아이디"),
-                                fieldWithPath("[].ingredient[].ingredientName").description("재료 이름"),
-                                fieldWithPath("[].ingredient[].requirement").description("재료 필수 여부")
-                        )))
-                .queryParam("userId", 1L)
+                .filter(document(DEFAULT_RESTDOCS_PATH))
                 .queryParam("pageNumber", 1)
                 .queryParam("pageSize", 3)
-                .when().get("/recipes/search/user")
+                .queryParam("userId", 1L)
+                .when().get("/recipes")
                 .then().log().all()
-                .body("size()", is(3));
+                .body("size()", is(3))
+                .body("[0].author.authorId", is(1))
+                .body("[1].author.authorId", is(1))
+                .body("[2].author.authorId", is(1));
     }
 }

--- a/backend/src/test/java/net/pengcook/recipe/repository/RecipeRepositoryTest.java
+++ b/backend/src/test/java/net/pengcook/recipe/repository/RecipeRepositoryTest.java
@@ -28,7 +28,7 @@ class RecipeRepositoryTest {
     void findRecipeIdsByCategoryAndKeyword() {
         Pageable pageable = PageRequest.of(0, 3);
 
-        List<Long> recipeIds = repository.findRecipeIdsByCategoryAndKeyword(null, null, pageable);
+        List<Long> recipeIds = repository.findRecipeIdsByCategoryAndKeyword(pageable, null, null, null);
 
         assertThat(recipeIds).containsExactly(15L, 14L, 13L);
     }

--- a/backend/src/test/java/net/pengcook/recipe/repository/RecipeRepositoryTest.java
+++ b/backend/src/test/java/net/pengcook/recipe/repository/RecipeRepositoryTest.java
@@ -25,10 +25,10 @@ class RecipeRepositoryTest {
 
     @Test
     @DisplayName("요청한 페이지에 해당하는 레시피 id 목록을 반환한다.")
-    void findRecipeIds() {
+    void findRecipeIdsByCategoryAndKeyword() {
         Pageable pageable = PageRequest.of(0, 3);
 
-        List<Long> recipeIds = repository.findRecipeIds(pageable);
+        List<Long> recipeIds = repository.findRecipeIdsByCategoryAndKeyword(null, null, pageable);
 
         assertThat(recipeIds).containsExactly(15L, 14L, 13L);
     }

--- a/backend/src/test/java/net/pengcook/recipe/service/RecipeServiceTest.java
+++ b/backend/src/test/java/net/pengcook/recipe/service/RecipeServiceTest.java
@@ -45,7 +45,7 @@ class RecipeServiceTest {
     @CsvSource(value = {"0,2,15", "1,2,13", "1,3,12"})
     @DisplayName("요청받은 페이지의 레시피 개요 목록을 조회한다.")
     void readRecipes(int pageNumber, int pageSize, int expectedFirstRecipeId) {
-        PageRecipeRequest pageRecipeRequest = new PageRecipeRequest(pageNumber, pageSize);
+        PageRecipeRequest pageRecipeRequest = new PageRecipeRequest(pageNumber, pageSize, null, null);
         List<MainRecipeResponse> mainRecipeResponses = recipeService.readRecipes(pageRecipeRequest);
 
         assertThat(mainRecipeResponses.getFirst().recipeId()).isEqualTo(expectedFirstRecipeId);
@@ -56,7 +56,7 @@ class RecipeServiceTest {
     void readRecipesWhenPageOffsetIsGreaterThanIntMaxValue() {
         int pageNumber = 1073741824;
         int pageSize = 2;
-        PageRecipeRequest pageRecipeRequest = new PageRecipeRequest(pageNumber, pageSize);
+        PageRecipeRequest pageRecipeRequest = new PageRecipeRequest(pageNumber, pageSize, null, null);
 
         assertThatThrownBy(() -> recipeService.readRecipes(pageRecipeRequest))
                 .isInstanceOf(InvalidParameterException.class);

--- a/backend/src/test/java/net/pengcook/recipe/service/RecipeServiceTest.java
+++ b/backend/src/test/java/net/pengcook/recipe/service/RecipeServiceTest.java
@@ -45,7 +45,8 @@ class RecipeServiceTest {
     @CsvSource(value = {"0,2,15", "1,2,13", "1,3,12"})
     @DisplayName("요청받은 페이지의 레시피 개요 목록을 조회한다.")
     void readRecipes(int pageNumber, int pageSize, int expectedFirstRecipeId) {
-        PageRecipeRequest pageRecipeRequest = new PageRecipeRequest(pageNumber, pageSize, null, null);
+        PageRecipeRequest pageRecipeRequest = new PageRecipeRequest(
+                pageNumber, pageSize, null, null, null);
         List<MainRecipeResponse> mainRecipeResponses = recipeService.readRecipes(pageRecipeRequest);
 
         assertThat(mainRecipeResponses.getFirst().recipeId()).isEqualTo(expectedFirstRecipeId);
@@ -56,7 +57,8 @@ class RecipeServiceTest {
     void readRecipesWhenPageOffsetIsGreaterThanIntMaxValue() {
         int pageNumber = 1073741824;
         int pageSize = 2;
-        PageRecipeRequest pageRecipeRequest = new PageRecipeRequest(pageNumber, pageSize, null, null);
+        PageRecipeRequest pageRecipeRequest = new PageRecipeRequest(
+                pageNumber, pageSize, null, null, null);
 
         assertThatThrownBy(() -> recipeService.readRecipes(pageRecipeRequest))
                 .isInstanceOf(InvalidParameterException.class);


### PR DESCRIPTION
### 동적 쿼리
`GET /recipes` 에 대해 파라미터가 필수와 옵션이 생겼습니다.
**필수** `pageNumber` `pageSize`
**옵션** `category` `keyword` `userId`

옵션은 `Nullable` 하며 해당 조건에 모두 부합하는 경우를 찾은 뒤 `Pageable` 이 적용됩니다.

### Deprecated
카테고리별 검색, 유저아이디별 검색 API 가 더 이상 사용되지 않을 예정이라 삭제를 해야할 것 같습니다.